### PR TITLE
convert from reqwest blocking to non-blocking to conform to wasm target

### DIFF
--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -26,11 +26,12 @@ log = { version = "0.4.21", features = ["kv", "kv_serde"] }
 md5 = "0.7.0"
 rand = "0.8.5"
 regex = "1.10.4"
-reqwest = { version = "0.12.4", features = ["blocking", "json"] }
+reqwest = { version = "0.12.4", features = ["json"] }
 semver = { version = "1.0.22", features = ["serde"] }
 serde = { version = "1.0.198", features = ["derive", "rc"] }
 serde_json = "1.0.116"
 thiserror = "1.0.60"
+tokio = { version = "1.34.0", features = ["rt", "time"] }
 url = "2.5.0"
 
 # pyo3 dependencies

--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eppo_core"
-version = "4.1.0"
+version = "4.1.1"
 edition = "2021"
 description = "Eppo SDK core library"
 repository = "https://github.com/Eppo-exp/rust-sdk"

--- a/eppo_core/src/poller_thread.rs
+++ b/eppo_core/src/poller_thread.rs
@@ -131,9 +131,13 @@ impl PollerThread {
             std::thread::Builder::new()
                 .name("eppo-poller".to_owned())
                 .spawn(move || {
+                    let runtime = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .unwrap();
                     loop {
                         log::debug!(target: "eppo", "fetching new configuration");
-                        let result = fetcher.fetch_configuration();
+                        let result = runtime.block_on(fetcher.fetch_configuration());
                         match result {
                             Ok(configuration) => {
                                 store.set_configuration(Arc::new(configuration));

--- a/eppo_core/src/poller_thread.rs
+++ b/eppo_core/src/poller_thread.rs
@@ -131,10 +131,16 @@ impl PollerThread {
             std::thread::Builder::new()
                 .name("eppo-poller".to_owned())
                 .spawn(move || {
-                    let runtime = tokio::runtime::Builder::new_current_thread()
+                    let runtime = match tokio::runtime::Builder::new_current_thread()
                         .enable_all()
                         .build()
-                        .unwrap();
+                    {
+                        Ok(runtime) => runtime,
+                        Err(err) => {
+                            update_result(Err(Error::from(err)));
+                            return;
+                        }
+                    };
                     loop {
                         log::debug!(target: "eppo", "fetching new configuration");
                         let result = runtime.block_on(fetcher.fetch_configuration());

--- a/python-sdk/Cargo.toml
+++ b/python-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eppo_py"
-version = "4.1.0"
+version = "4.1.1"
 edition = "2021"
 publish = false
 
@@ -8,7 +8,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-eppo_core = { version = "4.1.0", path = "../eppo_core", features = ["pyo3", "vendored"] }
+eppo_core = { version = "4.1.1", path = "../eppo_core", features = ["pyo3", "vendored"] }
 log = "0.4.22"
 pyo3 = { version = "0.22.0" }
 pyo3-log = "0.11.0"

--- a/ruby-sdk/Cargo.lock
+++ b/ruby-sdk/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "eppo_core"
-version = "4.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "626df025f5b474b42ead14953310e31e81e4b88ce52a993573bf87bc9def12d4"
 dependencies = [

--- a/ruby-sdk/ext/eppo_client/Cargo.toml
+++ b/ruby-sdk/ext/eppo_client/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 env_logger = { version = "0.11.3", features = ["unstable-kv"] }
-eppo_core = { version = "4.1.0", features = ["vendored"] }
+eppo_core = { version = "4.1.1", features = ["vendored"] }
 log = { version = "0.4.21", features = ["kv_serde"] }
 magnus = { version = "0.6.4" }
 serde = { version = "1.0.203", features = ["derive"] }

--- a/rust-sdk/Cargo.toml
+++ b/rust-sdk/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["config"]
 rust-version = "1.71.1"
 
 [dependencies]
-eppo_core = { version = "=4.1.0", path = "../eppo_core" }
+eppo_core = { version = "=4.1.1", path = "../eppo_core" }
 log = { version = "0.4.21", features = ["kv", "kv_serde"] }
 serde_json = "1.0.116"
 


### PR DESCRIPTION
## Motivation

To support compiling to a `wasm` target without using feature flags or other conditional compilation, we need to remove usage of the `blocking` client which is not supported.

## Description

* Replace usage of `reqwest::blocking` with non-blocking request
* Use `tokio` for async syncronization