### PR TITLE
chore(ruby): fix publish workflow by enabling logs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -181,6 +181,8 @@ jobs:
           script="puts EppoClient::Core::Client.new(EppoClient::Config.new('placeholder'))"
           ruby -reppo_client -e "$script" 2>&1 | grep 'fetching new configuration'
           echo "✅ Successfully installed gem"
+        env:
+          EPPO_LOG: "eppo=debug"
 
       - name: Set outputs
         id: set-outputs


### PR DESCRIPTION
Our smoke test checks for the presence of specific log line. We have changed the default log level to info, so the smoke test now fails.

Re-enable debug logs in CI.