### PR TITLE
chore: upgrade deprecated macos-12 builds to macos-latest

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -216,10 +216,10 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-12
+          - runner: macos-13
             target: x86_64
-          # - runner: macos-14
-          #   target: aarch64
+          - runner: macos-14
+            target: aarch64
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Observation

`macos-12` runner is deprecated and has stopped working:

<img width="1757" alt="Screenshot 2024-11-25 at 3 19 39 PM" src="https://github.com/user-attachments/assets/508cc244-3fd4-49b5-b599-cc9a747a7eec">

## Changes

Bumped to `macos-13` for `x86_64` and restored `aarch64` build on `macos-14`