### PR TITLE
chore(python): support free-threaded cpython-3.13, drop support for python-3.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ members = [
 [patch.crates-io]
 # Local override for development.
 eppo_core = { path = './eppo_core' }
+
+# https://github.com/Jij-Inc/serde-pyobject/pull/13
+serde-pyobject = { git = 'https://github.com/rasendubi/serde-pyobject', branch = 'chore-bump-pyo3' }

--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1.34.0", features = ["rt", "time"] }
 url = "2.5.0"
 
 # pyo3 dependencies
-pyo3 = { version = "0.22.0", optional = true, default-features = false }
+pyo3 = { version = "0.23.2", optional = true, default-features = false }
 serde-pyobject = { version = "0.4.0", optional = true}
 
 # vendored dependencies

--- a/python-sdk/Cargo.toml
+++ b/python-sdk/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 eppo_core = { version = "4.1.1", path = "../eppo_core", features = ["pyo3", "vendored"] }
 log = "0.4.22"
-pyo3 = { version = "0.22.0" }
-pyo3-log = "0.11.0"
+pyo3 = "0.23.2"
+pyo3-log = "0.12"
 serde-pyobject = "0.4.0"
 serde_json = "1.0.125"

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -8,7 +8,7 @@ description = "Eppo SDK for Python"
 readme = "README.md"
 authors = [{ name = "Eppo", email = "eppo-team@geteppo.com" }]
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Free-threaded cpython-3.13 requires pyo3-0.23.2.

serde-pyobject has not been updated yet, so I have submitted a [PR to update it](https://github.com/Jij-Inc/serde-pyobject/pull/13) + pinned my patched version for now.