### PR TITLE
chore: dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: gitsubmodule
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: cargo
+    directories:
+      - "/"
+      - "/eppo_core"
+      - "/rust-sdk"
+      - "/python-sdk"
+      - "/ruby-sdk/ext/eppo_client"
+    schedule:
+      interval: "weekly"
+
+
+  - package-ecosystem: pip
+    directory: "/python-sdk"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: bundler
+    directory: "/ruby-sdk"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Besides keeping our dependencies up-to-date, this should also update `sdk-test-data` submodule

Thanks @typotter for suggesting!