### PR TITLE
chore(deps): remove subdirectories from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,7 @@ updates:
       interval: "daily"
 
   - package-ecosystem: cargo
-    directories:
-      - "/"
-      - "/eppo_core"
-      - "/rust-sdk"
-      - "/python-sdk"
-      - "/ruby-sdk/ext/eppo_client"
+    directory: "/"
     schedule:
       interval: "weekly"
 


### PR DESCRIPTION
Dependabot seems to discover subdirectories just fine and opened duplicates (e.g., #97  and #94)