### PR TITLE
FF-3594 Decrease default poller jitter

### DIFF
--- a/eppo_core/src/poller_thread.rs
+++ b/eppo_core/src/poller_thread.rs
@@ -30,7 +30,7 @@ impl PollerThreadConfig {
     /// Default value for [`PollerThreadConfig::interval`].
     pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(30);
     /// Default value for [`PollerThreadConfig::jitter`].
-    pub const DEFAULT_POLL_JITTER: Duration = Duration::from_secs(30);
+    pub const DEFAULT_POLL_JITTER: Duration = Duration::from_secs(3);
 
     /// Create a new `PollerThreadConfig` using default configuration.
     pub fn new() -> PollerThreadConfig {


### PR DESCRIPTION
Our default jitter value was migrated from Python SDK. However, once we decreased the default poller interval, this made jitter value too high.

With 30s poll interval and 30s jitter, requests are made every 0–30 seconds (with average at 15s). That just doesn’t make much sense.

Decrease jitter value down to 3s, so it polls every 27–30s (avg 28.5s).