### PR TITLE
Revert "chore(python): support free-threaded cpython-3.13, drop support for python-3.8"

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -45,7 +45,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: 3.12
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -122,7 +122,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: 3.12
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -186,7 +186,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: 3.12
           architecture: ${{ matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -226,7 +226,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: 3.12
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,3 @@ members = [
 [patch.crates-io]
 # Local override for development.
 eppo_core = { path = './eppo_core' }
-
-# https://github.com/Jij-Inc/serde-pyobject/pull/13
-serde-pyobject = { git = 'https://github.com/rasendubi/serde-pyobject', branch = 'chore-bump-pyo3' }

--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1.34.0", features = ["rt", "time"] }
 url = "2.5.0"
 
 # pyo3 dependencies
-pyo3 = { version = "0.23.2", optional = true, default-features = false }
+pyo3 = { version = "0.22.0", optional = true, default-features = false }
 serde-pyobject = { version = "0.4.0", optional = true}
 
 # vendored dependencies

--- a/python-sdk/Cargo.toml
+++ b/python-sdk/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 eppo_core = { version = "4.1.1", path = "../eppo_core", features = ["pyo3", "vendored"] }
 log = "0.4.22"
-pyo3 = "0.23.2"
-pyo3-log = "0.12"
+pyo3 = { version = "0.22.0" }
+pyo3-log = "0.11.0"
 serde-pyobject = "0.4.0"
 serde_json = "1.0.125"

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -8,7 +8,7 @@ description = "Eppo SDK for Python"
 readme = "README.md"
 authors = [{ name = "Eppo", email = "eppo-team@geteppo.com" }]
 license = { file = "LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -8,7 +8,11 @@ description = "Eppo SDK for Python"
 readme = "README.md"
 authors = [{ name = "Eppo", email = "eppo-team@geteppo.com" }]
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+# python-3.13 requires pyo3-23.2. However, serde-pyobject is not
+# currently compatible with pyo3-23.
+#
+# See https://github.com/Jij-Inc/serde-pyobject/pull/13.
+requires-python = ">=3.8,<3.13"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Reverts Eppo-exp/eppo-multiplatform#79

I just realized we cannot override dependencies in the workspace because these overrides won't be preserved when we release the crate and will fail to build for our users.

We have to wait till serde-pyobject PR is merged. If that takes too long, we could fork or re-implement our serialization