### PR TITLE
chore: bump major version for core

### DIFF
--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eppo_core"
-version = "4.2.0"
+version = "5.0.0"
 edition = "2021"
 description = "Eppo SDK core library"
 repository = "https://github.com/Eppo-exp/rust-sdk"

--- a/fastly-edge-assignments/Cargo.toml
+++ b/fastly-edge-assignments/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 base64-url = "3.0.0"
 chrono = "0.4.19"
-eppo_core = { version = "=4.2.0", path = "../eppo_core" }
+eppo_core = { version = "=5.0.0", path = "../eppo_core" }
 fastly = "0.11.0"
 serde_json = "1.0.132"
 serde = "1.0.192"

--- a/python-sdk/Cargo.toml
+++ b/python-sdk/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-eppo_core = { version = "=4.2.0", path = "../eppo_core", features = ["pyo3", "vendored"] }
+eppo_core = { version = "=5.0.0", path = "../eppo_core", features = ["pyo3", "vendored"] }
 log = "0.4.22"
 pyo3 = { version = "0.22.0" }
 pyo3-log = "0.11.0"

--- a/ruby-sdk/ext/eppo_client/Cargo.toml
+++ b/ruby-sdk/ext/eppo_client/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 env_logger = { version = "0.11.3", features = ["unstable-kv"] }
-eppo_core = { version = "=4.2.0", features = ["vendored"] }
+eppo_core = { version = "=5.0.0", features = ["vendored"] }
 log = { version = "0.4.21", features = ["kv_serde"] }
 magnus = { version = "0.6.4" }
 serde = { version = "1.0.203", features = ["derive"] }

--- a/rust-sdk/Cargo.toml
+++ b/rust-sdk/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["config"]
 rust-version = "1.75.0"
 
 [dependencies]
-eppo_core = { version = "=4.2.0", path = "../eppo_core" }
+eppo_core = { version = "=5.0.0", path = "../eppo_core" }
 log = { version = "0.4.21", features = ["kv", "kv_serde"] }
 serde_json = "1.0.116"
 


### PR DESCRIPTION
We accidentally included breaking changes in 4.1.1, so bumping the major version now to correct that.