### PR TITLE
bug: wrap poller thread in `std::panic::catch_unwind` (FF-3468)

### DIFF
--- a/eppo_core/src/poller_thread.rs
+++ b/eppo_core/src/poller_thread.rs
@@ -171,9 +171,11 @@ impl PollerThread {
                                     return;
                                 }
                                 Err(RecvTimeoutError::Disconnected) => {
-                                    // The sender has disconnected.
-                                    // We simply sleep for the timeout duration and loop again.
-                                    std::thread::sleep(timeout);
+                                    // When the other end of channel disconnects, calls to
+                                    // .recv_timeout() return immediately.
+                                    // Stop the thread.
+                                    log::debug!(target: "eppo", "poller thread received disconnected");
+                                    return;
                                 }
                             }
                         }

--- a/python-sdk/Cargo.toml
+++ b/python-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eppo_py"
-version = "4.1.2"
+version = "4.1.3"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Motivation

Customer observed segfaults sometimes during process shutdown.

## Description

**Change 1 (Likely Root Cause):**
When the parent process disconnects from the thread’s shared channel, the thread attempts another run. During shutdown, this may cause the thread to access memory that the Python interpreter has already released.

**Change 2:**
Wraps the thread’s execution in a catch_unwind (try/catch equivalent) to handle unexpected panics more gracefully. (edited)

<img width="1281" alt="Screenshot 2024-12-09 at 10 20 32 AM" src="https://github.com/user-attachments/assets/fe8bb4a6-9193-4c54-acf4-c79d0a6f1af8">

**Change 3: Already merged**

There is an unreleased improvement to the `poller_thread` that handles exceptions from HTTP errors and returns a `Result` - https://github.com/Eppo-exp/eppo-multiplatform/commit/41376295f59ba9f6325c1abe83ebb4f147785d43

The customers' environment did not have this change and it could also be the root cause.

## Deployment

The `eppo_core@5.0.0` branch is not yet released - it was our intention to do so after some upcoming features are merged (https://github.com/Eppo-exp/eppo-multiplatform/pull/113).

1. To expedite this improvement to the poller I can merge and deploy python `4.1.3` against `eppo_core@4.x.y`
2. We can merge the PR above and roll both our with the version numbers in this PR.