### PR TITLE
fix(rust,ruby): fix serialization format for AttributeValue

### DIFF
--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -12,6 +12,8 @@ rust-version = "1.75.0"
 [features]
 # Add implementation of `FromPyObject`/`ToPyObject` for some types.
 pyo3 = ["dep:pyo3", "dep:serde-pyobject"]
+# Add implementation of `TryConvert`/`IntoValue` for some types.
+magnus = ["dep:magnus", "dep:serde_magnus"]
 # Vendor any external libraries that we need (OpenSSL on Linux), so we
 # don’t depend on shared libraries.
 #
@@ -39,6 +41,10 @@ url = "2.5.0"
 # pyo3 dependencies
 pyo3 = { version = "0.22.0", optional = true, default-features = false }
 serde-pyobject = { version = "0.4.0", optional = true}
+
+# magnus dependencies
+magnus = { version = "0.6.4", default-features = false, optional = true }
+serde_magnus = { version = "0.8.1", default-features = false, optional = true }
 
 # vendored dependencies
 [target.'cfg(all(target_os = "linux", target_arch = "s390x"))'.dependencies]

--- a/eppo_core/src/eval/eval_details.rs
+++ b/eppo_core/src/eval/eval_details.rs
@@ -278,7 +278,7 @@ mod magnus_impl {
 
     impl<T: IntoValue> IntoValue for EvaluationResultWithDetails<T> {
         fn into_value_with(self, handle: &magnus::Ruby) -> magnus::Value {
-            let hash = handle.hash_new_capa(3);
+            let hash = handle.hash_new();
             let _ = hash.aset(handle.sym_new("variation"), self.variation);
             let _ = hash.aset(handle.sym_new("action"), self.action);
             let _ = hash.aset(

--- a/eppo_core/src/events.rs
+++ b/eppo_core/src/events.rs
@@ -119,3 +119,24 @@ mod pyo3_impl {
         }
     }
 }
+
+#[cfg(feature = "magnus")]
+mod magnus_impl {
+    use magnus::IntoValue;
+
+    use super::{AssignmentEvent, BanditEvent};
+
+    impl IntoValue for AssignmentEvent {
+        fn into_value_with(self, _handle: &magnus::Ruby) -> magnus::Value {
+            serde_magnus::serialize(&self)
+                .expect("AssignmentEvent should always be serializable to Ruby")
+        }
+    }
+
+    impl IntoValue for BanditEvent {
+        fn into_value_with(self, _handle: &magnus::Ruby) -> magnus::Value {
+            serde_magnus::serialize(&self)
+                .expect("BanditEvent should always be serializable to Ruby")
+        }
+    }
+}

--- a/eppo_core/src/ufc/assignment.rs
+++ b/eppo_core/src/ufc/assignment.rs
@@ -393,7 +393,7 @@ mod magnus_impl {
 
     impl IntoValue for Assignment {
         fn into_value_with(self, handle: &Ruby) -> magnus::Value {
-            let hash = handle.hash_new_capa(2);
+            let hash = handle.hash_new();
             let _ = hash.aset(handle.sym_new("value"), self.value);
             let _ = hash.aset(
                 handle.sym_new("event"),

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "test": "npm run with-server 'npm-run-all test:*'",
     "test:rust": "cargo test",
     "test:python": "cd python-sdk && pytest",
-    "test:ruby": "cd ruby-sdk && bundle exec rake test",
+    "test:ruby": "cd ruby-sdk && bundle exec rake build && bundle exec rspec",
     "with-server": "start-server-and-test start-mock-server http://127.0.0.1:8378",
     "start-mock-server": "npm start --prefix ./mock-server"
   },

--- a/ruby-sdk/Cargo.lock
+++ b/ruby-sdk/Cargo.lock
@@ -240,6 +240,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "eppo_client"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "env_logger",
  "eppo_core",
@@ -324,19 +368,23 @@ dependencies = [
 
 [[package]]
 name = "eppo_core"
-version = "4.1.1"
+version = "5.0.0"
 dependencies = [
  "chrono",
  "derive_more",
  "faststr",
  "log",
+ "magnus",
  "md5",
  "rand",
  "regex",
  "reqwest",
  "semver",
  "serde",
+ "serde-bool",
  "serde_json",
+ "serde_magnus",
+ "serde_with",
  "thiserror",
  "tokio",
  "url",
@@ -501,6 +549,12 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -762,6 +816,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +1034,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1140,12 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1376,6 +1448,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-bool"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af14f9242b0beec13757cf161feb2d600c11a764310425c3429dca9925b7a92"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,6 +1509,34 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1484,6 +1593,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1659,6 +1774,25 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "tinystr"

--- a/ruby-sdk/README.md
+++ b/ruby-sdk/README.md
@@ -38,6 +38,23 @@ eppo_core = { path = '../eppo_core' }
 
 Make sure you remove the override before updating `Cargo.lock`. Otherwise, the lock file will be missing `eppo_core` checksum and will be unsuitable for release. (CI will warn you if you do this accidentally.)
 
+## Build locally
+
+Install all dependencies:
+```sh
+bundle install
+```
+
+Build native extension:
+```sh
+bundle exec rake build
+```
+
+Run tests:
+```sh
+bundle exec rspec
+```
+
 ## Releasing
 
 * Bump versions in `ruby-sdk/lib/eppo_client/version.rb` and `ruby-sdk/ext/eppo_client/Cargo.toml`

--- a/ruby-sdk/ext/eppo_client/Cargo.toml
+++ b/ruby-sdk/ext/eppo_client/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 env_logger = { version = "0.11.3", features = ["unstable-kv"] }
-eppo_core = { version = "=5.0.0", features = ["vendored"] }
+eppo_core = { version = "=5.0.0", features = ["vendored", "magnus"] }
 log = { version = "0.4.21", features = ["kv_serde"] }
 magnus = { version = "0.6.4" }
 serde = { version = "1.0.203", features = ["derive"] }

--- a/ruby-sdk/lib/eppo_client/client.rb
+++ b/ruby-sdk/lib/eppo_client/client.rb
@@ -122,7 +122,7 @@ module EppoClient
 
         log_assignment(assignment[:event])
 
-        return assignment[:value][:value]
+        return assignment[:value]
       rescue StandardError => error
         logger.debug("[Eppo SDK] Failed to get assignment: #{error}")
 
@@ -139,9 +139,6 @@ module EppoClient
 
       if not result[:variation] then
         result[:variation] = default_value
-      else
-        # unwrap from AssignmentValue to untyped value
-        result[:variation] = result[:variation][:value]
       end
 
       return result


### PR DESCRIPTION
There's an unreleased bug in Ruby whereas get_json_assignment returned two-field object with :raw and :parsed fields instead of just parsed value.

This is due to AttributeValue changing internal format for JSON variant.

Implement Serialize manually for AttributeValue, so only serialize parsed value.

This commit also adds implementation for magnus' IntoValue/TryConvert in eppo core, so we're slightly less reliant on magnus_serde.