### PR TITLE
fest(core): support type-preserving numeric and boolean categorical attributes

### DIFF
--- a/eppo_core/src/eval/eval_assignment.rs
+++ b/eppo_core/src/eval/eval_assignment.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 
 use crate::{
-    attributes::Subject,
     error::{EvaluationError, EvaluationFailure},
     events::AssignmentEvent,
     ufc::{
@@ -20,6 +19,7 @@ use super::{
         EvalAllocationVisitor, EvalAssignmentVisitor, EvalRuleVisitor, EvalSplitVisitor,
         NoopEvalVisitor,
     },
+    subject::Subject,
 };
 
 /// Evaluate the specified feature flag for the given subject and return assigned variation and

--- a/eppo_core/src/eval/eval_bandits.rs
+++ b/eppo_core/src/eval/eval_bandits.rs
@@ -383,6 +383,8 @@ fn score_attributes(
             attributes
                 .numeric
                 .get(&coef.attribute_key)
+                .cloned()
+                .map(f64::from)
                 // fend against infinite/NaN attributes as they poison the calculation down the line
                 .filter(|n| n.is_finite())
                 .map(|value| value * coef.coefficient)
@@ -392,7 +394,7 @@ fn score_attributes(
             attributes
                 .categorical
                 .get(&coef.attribute_key)
-                .and_then(|value| coef.value_coefficients.get(value.as_str()))
+                .and_then(|value| coef.value_coefficients.get(value.to_str().as_ref()))
                 .copied()
                 .unwrap_or(coef.missing_value_coefficient)
         }))
@@ -410,8 +412,8 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     use crate::{
-        eval::get_bandit_action, ufc::UniversalFlagConfig, Configuration, ContextAttributes,
-        SdkMetadata, Str,
+        eval::get_bandit_action, ufc::UniversalFlagConfig, CategoricalAttribute, Configuration,
+        ContextAttributes, NumericAttribute, SdkMetadata, Str,
     };
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -434,8 +436,8 @@ mod tests {
     #[derive(Debug, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct TestContextAttributes {
-        numeric_attributes: HashMap<String, f64>,
-        categorical_attributes: HashMap<String, Str>,
+        numeric_attributes: HashMap<String, NumericAttribute>,
+        categorical_attributes: HashMap<String, CategoricalAttribute>,
     }
     impl From<TestContextAttributes> for ContextAttributes {
         fn from(value: TestContextAttributes) -> ContextAttributes {

--- a/eppo_core/src/eval/mod.rs
+++ b/eppo_core/src/eval/mod.rs
@@ -5,6 +5,7 @@ mod eval_precomputed_assignments;
 mod eval_rules;
 mod eval_visitor;
 mod evaluator;
+mod subject;
 
 pub mod eval_details;
 

--- a/eppo_core/src/eval/subject.rs
+++ b/eppo_core/src/eval/subject.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use crate::Str;
+
+use crate::{AttributeValue, Attributes};
+
+/// `Subject` is a bundle of subject attributes and a key.
+#[derive(Debug)]
+pub(super) struct Subject {
+    /// Subject key encoded as attribute value. Known to be `AttributeValue::String`. This is
+    /// done to allow returning subject key as an attribute when rule references "id".
+    key: AttributeValue,
+    attributes: Arc<Attributes>,
+}
+
+impl Subject {
+    pub fn new(key: Str, attributes: Arc<Attributes>) -> Subject {
+        Subject {
+            key: AttributeValue::from(key),
+            attributes,
+        }
+    }
+
+    pub fn key(&self) -> &Str {
+        let Some(s) = self.key.as_str() else {
+            unreachable!("Subject::key is always encoded as categorical string attribute");
+        };
+        s
+    }
+
+    pub fn get_attribute(&self, name: &str) -> Option<&AttributeValue> {
+        let value = self.attributes.get(name);
+        if value.is_some() {
+            return value;
+        }
+
+        if name == "id" {
+            return Some(&self.key);
+        }
+
+        None
+    }
+}

--- a/eppo_core/src/events.rs
+++ b/eppo_core/src/events.rs
@@ -2,7 +2,11 @@ use std::{collections::HashMap, sync::Arc};
 
 use serde::Serialize;
 
-use crate::{eval::eval_details::EvaluationDetails, Attributes, SdkMetadata, Str};
+use crate::{
+    attributes::{Attributes, CategoricalAttribute, NumericAttribute},
+    eval::eval_details::EvaluationDetails,
+    SdkMetadata, Str,
+};
 
 /// Events that can be emitted during evaluation of assignment or bandit. They need to be logged to
 /// analytics storage and fed back to Eppo for analysis.
@@ -64,10 +68,10 @@ pub struct BanditEvent {
     pub optimality_gap: f64,
     pub model_version: String,
     pub timestamp: String,
-    pub subject_numeric_attributes: HashMap<String, f64>,
-    pub subject_categorical_attributes: HashMap<String, Str>,
-    pub action_numeric_attributes: HashMap<String, f64>,
-    pub action_categorical_attributes: HashMap<String, Str>,
+    pub subject_numeric_attributes: HashMap<String, NumericAttribute>,
+    pub subject_categorical_attributes: HashMap<String, CategoricalAttribute>,
+    pub action_numeric_attributes: HashMap<String, NumericAttribute>,
+    pub action_categorical_attributes: HashMap<String, CategoricalAttribute>,
     pub meta_data: EventMetaData,
 }
 

--- a/eppo_core/src/lib.rs
+++ b/eppo_core/src/lib.rs
@@ -49,6 +49,7 @@
 
 #![warn(rustdoc::missing_crate_level_docs)]
 
+pub mod attributes;
 pub mod bandits;
 pub mod configuration_fetcher;
 pub mod configuration_store;
@@ -61,9 +62,7 @@ pub mod sharder;
 pub mod timestamp;
 pub mod ufc;
 
-mod attributes;
 mod configuration;
-mod context_attributes;
 mod error;
 mod obfuscation;
 mod precomputed;
@@ -71,8 +70,9 @@ mod sdk_metadata;
 mod str;
 
 pub use crate::str::Str;
-pub use attributes::{AttributeValue, Attributes};
+pub use attributes::{
+    AttributeValue, Attributes, CategoricalAttribute, ContextAttributes, NumericAttribute,
+};
 pub use configuration::Configuration;
-pub use context_attributes::ContextAttributes;
 pub use error::{Error, EvaluationError, Result};
 pub use sdk_metadata::SdkMetadata;

--- a/python-sdk/tests/test_context_attributes.py
+++ b/python-sdk/tests/test_context_attributes.py
@@ -26,6 +26,18 @@ def test_bool_as_numeric():
     assert attrs.numeric_attributes == {"true": 1.0, "false": 0.0}
 
 
+def test_preserves_types_for_categorical_attributes():
+    attrs = ContextAttributes(
+        numeric_attributes={},
+        categorical_attributes={"bool": True, "number": 42, "string": "hello"},
+    )
+    assert attrs.categorical_attributes == {
+        "bool": True,
+        "number": 42,
+        "string": "hello",
+    }
+
+
 def test_empty():
     attrs = ContextAttributes.empty()
 
@@ -56,7 +68,7 @@ def test_from_dict_bool():
     )
     assert attrs.numeric_attributes == {}
     assert attrs.categorical_attributes == {
-        "categorical": "true",
+        "categorical": True,
     }
 
 

--- a/rust-sdk/src/lib.rs
+++ b/rust-sdk/src/lib.rs
@@ -64,7 +64,7 @@ use eppo_core::SdkMetadata;
 #[doc(inline)]
 pub use eppo_core::{
     eval::eval_details::*, events::AssignmentEvent, ufc::AssignmentValue, AttributeValue,
-    Attributes, Error, EvaluationError, Result,
+    Attributes, CategoricalAttribute, Error, EvaluationError, NumericAttribute, Result,
 };
 
 pub use assignment_logger::AssignmentLogger;


### PR DESCRIPTION
Note: the PR is currently open against #123 to minimize diff

So, besides allowing numbers and booleans for categorical attributes this PR basically makes regular `Attributes` aware of their kind (categorical or numeric). So translation between `Attributes` and `ContextAttributes` is more faithful:
```rust
// pseudocode
ContextAttributes {
  categorical: {
    "string": CategoricalAttribute::String("hello"),
    "numeric": CategoricalAttribute::Numeric(42),
    "boolean": CategoricalAttribute::Boolean(true),
  },
  numeric: {
    "another_numeric": NumericAttribute::Numeric(12),
  },
}.to_generic_attributes() == Attributes {
  "string": AttributeValue::Categorical(CategoricalAttribute::String("hello")),
  "numeric": AttributeValue::Categorical(CategoricalAttribute::Numeric(42)),
  "boolean": AttributeValue::Categorical(CategoricalAttribute::Boolean(true)),
  "another_numeric": AttributeValue::Numeric(NumericAttribute(12)),
}
```
so, it's trivial to convert back and forth between these types.

This is a breaking change for Rust users but that should be an easy migration as all types implement `From` for strings, numbers, and booleans.