### PR TITLE
chore(ci): properly quote ruby versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby: [3.0, 3.1, 3.2, 3.3]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
 
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Ruby & Rust
         uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: "${{ matrix.ruby }}"
           bundler-cache: true
           cargo-cache: true
           rubygems: '3.5.11'


### PR DESCRIPTION
YAML interpreted 3.0 as a number and stripped ".0" when installing Ruby. So this caused the latest Ruby version to be installed (instead of 3.0).

With Ruby-3.4 recently released, this broke our CI because ruby-3.4 is not currently supported by our version of rb_sys.