### PR TITLE
chore: remove -o pipefail as it's not a POSIX shell option

### DIFF
--- a/eppo_core/postversion.sh
+++ b/eppo_core/postversion.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -euxo pipefail
+set -eux
 
 VERSION="$(jq -r .version ./package.json)"
 

--- a/python-sdk/postversion.sh
+++ b/python-sdk/postversion.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -euxo pipefail
+set -eux
 
 VERSION="$(jq -r .version ./package.json)"
 

--- a/ruby-sdk/postversion.sh
+++ b/ruby-sdk/postversion.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -euxo pipefail
+set -eux
 
 VERSION="$(jq -r .version ./package.json)"
 

--- a/rust-sdk/postversion.sh
+++ b/rust-sdk/postversion.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -euxo pipefail
+set -eux
 
 VERSION="$(jq -r .version ./package.json)"
 


### PR DESCRIPTION
Accidentally used a non-posix option in #136 and this caused CI fail. Just drop it — shouldn't matter as we're not using pipes anyway