### PR TITLE
bug: publish macos wheels for python 3.9, 3.10, 3.11 and 3.12 (FF-3786)

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -220,19 +220,25 @@ jobs:
             target: x86_64
           - runner: macos-14
             target: aarch64
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          # aarch64 builds only supported from 3.10 and up
+          - platform: { runner: macos-14, target: aarch64 }
+            python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: ${{ matrix.python-version }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path ./python-sdk/Cargo.toml
+          args: --release --out dist --interpreter ${{ matrix.python-version }} --manifest-path ./python-sdk/Cargo.toml
           sccache: 'true'
+
       - name: List dist directory
         run: ls -l dist
       - name: Upload wheels

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -221,10 +221,6 @@ jobs:
           - runner: macos-14
             target: aarch64
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        exclude:
-          # aarch64 builds only supported from 3.10 and up
-          - platform: { runner: macos-14, target: aarch64 }
-            python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -240,7 +240,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-macos-${{ matrix.platform.target }}
+          name: wheels-macos-${{ matrix.platform.target }}-py${{ matrix.python-version }}
           path: dist
       - name: pytest
         run: |


### PR DESCRIPTION
## Research:

* https://www.maturin.rs/distribution.html#build-wheels

```
Usage: maturin build [OPTIONS] [ARGS]...

Arguments:
  [ARGS]...
          Rustc flags

Options:
  -i, --interpreter [<INTERPRETER>...]
          The python versions to build wheels for, given as the executables of interpreters such as `python3.9` or `/usr/bin/python3.8`

  -f, --find-interpreter
          Find interpreters from the host machine
```

* https://github.com/pydantic/pydantic-core/blob/main/.github/workflows/ci.yml#L474C1-L484C32

## Testing

We actions log: https://github.com/Eppo-exp/eppo-multiplatform/actions/runs/12680906304/job/35343576093?pr=144

<img width="1853" alt="Screenshot 2025-01-08 at 3 39 25 PM" src="https://github.com/user-attachments/assets/caf9720e-8b7b-4364-bfbd-2beddabf2af7" />
<img width="1853" alt="Screenshot 2025-01-08 at 3 39 43 PM" src="https://github.com/user-attachments/assets/8809bc82-9f16-4c23-81d8-535d8b742bc6" />
![Uploading Screenshot 2025-01-08 at 3.40.08 PM.png…]()
