### PR TITLE
publish python 3.9+ on linux and windows platforms

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,20 +39,21 @@ jobs:
             target: s390x
           - runner: ubuntu-latest
             target: ppc64le
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: ${{ matrix.python-version }}
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         if: ${{ startsWith(matrix.platform.target, 'x86') }}
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path ./python-sdk/Cargo.toml
+          args: --release --out dist --interpreter ${{ matrix.python-version }} --manifest-path ./python-sdk/Cargo.toml
           sccache: 'true'
           manylinux: auto
           before-script-linux: |
@@ -62,7 +63,7 @@ jobs:
         if: ${{ !startsWith(matrix.platform.target, 'x86') }}
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path ./python-sdk/Cargo.toml
+          args: --release --out dist --interpreter ${{ matrix.python-version }} --manifest-path ./python-sdk/Cargo.toml
           sccache: 'true'
           manylinux: auto
           before-script-linux: |
@@ -72,7 +73,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux-${{ matrix.platform.target }}
+          name: wheels-linux-${{ matrix.platform.target }}-py${{ matrix.python-version }}
           path: dist
 
       - name: pytest
@@ -116,24 +117,25 @@ jobs:
             target: aarch64
           - runner: ubuntu-latest
             target: armv7
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: ${{ matrix.python-version }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path ./python-sdk/Cargo.toml
+          args: --release --out dist --interpreter ${{ matrix.python-version }} --manifest-path ./python-sdk/Cargo.toml
           sccache: 'true'
           manylinux: musllinux_1_2
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-musllinux-${{ matrix.platform.target }}
+          name: wheels-musllinux-${{ matrix.platform.target }}-py${{ matrix.python-version }}
           path: dist
       - name: pytest
         if: ${{ startsWith(matrix.platform.target, 'x86_64') }}


### PR DESCRIPTION
Did work for (https://github.com/Eppo-exp/eppo-multiplatform/pull/144) but forgot to publish for linux and windows on py3.9+