### PR TITLE
Revert "publish python 3.9+ on linux and windows platforms"

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,21 +39,20 @@ jobs:
             target: s390x
           - runner: ubuntu-latest
             target: ppc64le
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.12
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         if: ${{ startsWith(matrix.platform.target, 'x86') }}
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter ${{ matrix.python-version }} --manifest-path ./python-sdk/Cargo.toml
+          args: --release --out dist --find-interpreter --manifest-path ./python-sdk/Cargo.toml
           sccache: 'true'
           manylinux: auto
           before-script-linux: |
@@ -63,7 +62,7 @@ jobs:
         if: ${{ !startsWith(matrix.platform.target, 'x86') }}
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter ${{ matrix.python-version }} --manifest-path ./python-sdk/Cargo.toml
+          args: --release --out dist --find-interpreter --manifest-path ./python-sdk/Cargo.toml
           sccache: 'true'
           manylinux: auto
           before-script-linux: |
@@ -73,7 +72,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux-${{ matrix.platform.target }}-py${{ matrix.python-version }}
+          name: wheels-linux-${{ matrix.platform.target }}
           path: dist
 
       - name: pytest
@@ -117,25 +116,24 @@ jobs:
             target: aarch64
           - runner: ubuntu-latest
             target: armv7
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.12
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter ${{ matrix.python-version }} --manifest-path ./python-sdk/Cargo.toml
+          args: --release --out dist --find-interpreter --manifest-path ./python-sdk/Cargo.toml
           sccache: 'true'
           manylinux: musllinux_1_2
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-musllinux-${{ matrix.platform.target }}-py${{ matrix.python-version }}
+          name: wheels-musllinux-${{ matrix.platform.target }}
           path: dist
       - name: pytest
         if: ${{ startsWith(matrix.platform.target, 'x86_64') }}


### PR DESCRIPTION
Reverts Eppo-exp/eppo-multiplatform#146.

#146 seem to have broken `main` and it wasn't necessary as we're building linux correctly for multiple versions, and #146 actually removed builds for PyPy:
<img width="836" alt="Screenshot 2025-01-10 at 01 37 25" src="https://github.com/user-attachments/assets/219ee00d-38ea-4e94-80c3-22aedc7e06a2" />

and for Windows:
<img width="1002" alt="image" src="https://github.com/user-attachments/assets/c21ade3a-12c7-4d7c-b5fe-84a004ca3a2a" />
