### PR TITLE
feat(events): Add `VecEventQueue` abstraction, event status and attempts

### DIFF
--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -64,7 +64,7 @@ openssl-src = { version = "~300.2", optional = true }
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 env_logger = "0.11.3"
-wiremock = "0.5.1"
+wiremock = "0.6.2"
 
 [[bench]]
 name = "evaluation_details"

--- a/eppo_core/src/eval/eval_details_builder.rs
+++ b/eppo_core/src/eval/eval_details_builder.rs
@@ -230,9 +230,10 @@ impl EvalBanditVisitor for EvalDetailsBuilder {
 }
 
 impl<'b> EvalAssignmentVisitor for &'b mut EvalDetailsBuilder {
-    type AllocationVisitor<'a> =
-        <EvalDetailsBuilder as EvalAssignmentVisitor>::AllocationVisitor<'a>
-    where Self: 'a;
+    type AllocationVisitor<'a>
+        = <EvalDetailsBuilder as EvalAssignmentVisitor>::AllocationVisitor<'a>
+    where
+        Self: 'a;
 
     fn visit_allocation<'a>(&'a mut self, allocation: &Allocation) -> Self::AllocationVisitor<'a> {
         EvalAssignmentVisitor::visit_allocation(*self, allocation)
@@ -252,7 +253,8 @@ impl<'b> EvalAssignmentVisitor for &'b mut EvalDetailsBuilder {
 }
 
 impl EvalAssignmentVisitor for EvalDetailsBuilder {
-    type AllocationVisitor<'a> = EvalAllocationDetailsBuilder<'a>
+    type AllocationVisitor<'a>
+        = EvalAllocationDetailsBuilder<'a>
     where
         Self: 'a;
 
@@ -302,11 +304,13 @@ impl EvalAssignmentVisitor for EvalDetailsBuilder {
 }
 
 impl<'b> EvalAllocationVisitor for EvalAllocationDetailsBuilder<'b> {
-    type RuleVisitor<'a> = EvalRuleDetailsBuilder<'a>
+    type RuleVisitor<'a>
+        = EvalRuleDetailsBuilder<'a>
     where
         Self: 'a;
 
-    type SplitVisitor<'a> = EvalSplitDetailsBuilder<'a>
+    type SplitVisitor<'a>
+        = EvalSplitDetailsBuilder<'a>
     where
         Self: 'a;
 

--- a/eppo_core/src/events.rs
+++ b/eppo_core/src/events.rs
@@ -1,6 +1,8 @@
-mod event_dispatcher;
 mod event;
 mod event_delivery;
+mod event_dispatcher;
+mod queued_event;
+mod vec_event_queue;
 
 use std::{collections::HashMap, sync::Arc};
 

--- a/eppo_core/src/events/event.rs
+++ b/eppo_core/src/events/event.rs
@@ -1,7 +1,7 @@
 use crate::timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub struct Event {
     pub uuid: uuid::Uuid,
     pub timestamp: Timestamp,

--- a/eppo_core/src/events/event.rs
+++ b/eppo_core/src/events/event.rs
@@ -1,7 +1,7 @@
 use crate::timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Event {
     pub uuid: uuid::Uuid,
     pub timestamp: Timestamp,

--- a/eppo_core/src/events/event_delivery.rs
+++ b/eppo_core/src/events/event_delivery.rs
@@ -1,7 +1,7 @@
 use crate::events::event::Event;
 use crate::{Error, Str};
 use log::{debug, info};
-use reqwest::{StatusCode};
+use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use url::{ParseError, Url};
 use uuid::Uuid;
@@ -39,8 +39,12 @@ impl EventDelivery {
         let ingestion_url = self.ingestion_url;
         let sdk_key = &self.sdk_key;
         debug!("Delivering {} events to {}", events.len(), ingestion_url);
-        let body = IngestionRequestBody { eppo_events: events };
-        let response = self.client.post(ingestion_url)
+        let body = IngestionRequestBody {
+            eppo_events: events,
+        };
+        let response = self
+            .client
+            .post(ingestion_url)
             .header("X-Eppo-Token", sdk_key.as_str())
             .json(&body)
             .send()
@@ -57,7 +61,10 @@ impl EventDelivery {
             }
         })?;
         let response = response.json::<EventDeliveryResponse>().await?;
-        info!("Batch delivered successfully, {} events failed ingestion", response.failed_events.len());
+        info!(
+            "Batch delivered successfully, {} events failed ingestion",
+            response.failed_events.len()
+        );
         Ok(response)
     }
 }

--- a/eppo_core/src/events/event_dispatcher.rs
+++ b/eppo_core/src/events/event_dispatcher.rs
@@ -104,10 +104,11 @@ impl<T: EventQueue + Clone> EventDispatcher<T> {
                                 },
                                 Some(EventDispatcherCommand::Event(event)) => {
                                     if Err(QueueError::QueueFull) == event_queue.push(event) {
+                                        // if queue is ALREADY full, we can't add any new events to it
                                         warn!("Event queue is full, dropping event");
-                                    }
-                                    if event_queue.is_batch_full() {
-                                        // Reached max batch size -> send events immediately
+                                    } else if event_queue.is_batch_full() {
+                                        // Pushing this event caused us to reach max batch size.
+                                        // Thus, send events immediately
                                         break;
                                     } // else loop to get more events
                                 },

--- a/eppo_core/src/events/event_dispatcher.rs
+++ b/eppo_core/src/events/event_dispatcher.rs
@@ -1,12 +1,14 @@
 use crate::events::event::Event;
-use log::{warn};
+use crate::events::event_delivery::EventDelivery;
+use crate::events::queued_event::{QueuedEvent, QueuedEventStatus};
+use crate::events::vec_event_queue::{EventQueue, QueueError};
+use log::warn;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::time::{Duration, Instant};
-use crate::events::event_delivery::EventDelivery;
 
 #[derive(Debug)]
 pub enum EventDispatcherCommand {
-    Event(Event),
+    Event(QueuedEvent),
     Flush,
 }
 
@@ -22,24 +24,32 @@ pub struct EventDispatcherConfig {
     pub retry_interval: Duration,
     pub max_retry_delay: Duration,
     pub max_retries: Option<u32>,
-    pub batch_size: usize,
 }
 
 /// EventDispatcher is responsible for batching events and delivering them to the ingestion service
 /// via [`EventDelivery`].
-pub struct EventDispatcher {
+pub struct EventDispatcher<T> {
     config: EventDispatcherConfig,
+    event_queue: T,
     tx: UnboundedSender<EventDispatcherCommand>,
 }
 
-impl EventDispatcher {
-    pub fn new(config: EventDispatcherConfig, tx: UnboundedSender<EventDispatcherCommand>) -> Self {
-        EventDispatcher { config, tx }
+impl<T: EventQueue + Clone> EventDispatcher<T> {
+    pub fn new(
+        config: EventDispatcherConfig,
+        event_queue: T,
+        tx: UnboundedSender<EventDispatcherCommand>,
+    ) -> Self {
+        EventDispatcher {
+            config,
+            tx,
+            event_queue,
+        }
     }
 
     /// Enqueues an event in the batch event processor and starts delivery if needed.
     pub fn dispatch(&self, event: Event) -> Result<(), &str> {
-        self.send(EventDispatcherCommand::Event(event))
+        self.send(EventDispatcherCommand::Event(QueuedEvent::new(event)))
     }
 
     pub fn send(&self, command: EventDispatcherCommand) -> Result<(), &str> {
@@ -51,14 +61,10 @@ impl EventDispatcher {
 
     async fn event_dispatcher(&self, rx: &mut UnboundedReceiver<EventDispatcherCommand>) {
         let config = self.config.clone();
-        let batch_size = config.batch_size;
-        let event_delivery = EventDelivery::new(
-            config.sdk_key.into(),
-            config.ingestion_url.into()
-        ).expect("Failed to create EventDelivery. invalid ingestion URL");
+        let event_queue = self.event_queue.clone();
+        let event_delivery = EventDelivery::new(config.sdk_key.into(), config.ingestion_url.into())
+            .expect("Failed to create EventDelivery. invalid ingestion URL");
         loop {
-            let mut batch_queue: Vec<Event> = Vec::with_capacity(batch_size);
-
             // Wait for the first event in the batch.
             //
             // Optimization: Moved outside the loop below, so we're not woken up on regular intervals
@@ -69,7 +75,11 @@ impl EventDispatcher {
                     // Channel closed, no more messages. Exit the main loop.
                     return;
                 }
-                Some(EventDispatcherCommand::Event(event)) => batch_queue.push(event),
+                Some(EventDispatcherCommand::Event(event)) => {
+                    if Err(QueueError::QueueFull) == event_queue.push(event) {
+                        warn!("Event queue is full, dropping event");
+                    }
+                }
                 Some(EventDispatcherCommand::Flush) => {
                     // No buffered events yet, nothing to flush.
                     continue;
@@ -77,7 +87,7 @@ impl EventDispatcher {
             }
 
             // short-circuit for batch size of 1
-            if batch_queue.len() < batch_size {
+            if !event_queue.is_batch_full() {
                 let deadline = Instant::now() + config.delivery_interval;
                 // Loop until we have enough events to send or reached deadline.
                 loop {
@@ -93,8 +103,10 @@ impl EventDispatcher {
                                     break;
                                 },
                                 Some(EventDispatcherCommand::Event(event)) => {
-                                    batch_queue.push(event);
-                                    if batch_queue.len() >= batch_size {
+                                    if Err(QueueError::QueueFull) == event_queue.push(event) {
+                                        warn!("Event queue is full, dropping event");
+                                    }
+                                    if event_queue.is_batch_full() {
                                         // Reached max batch size -> send events immediately
                                         break;
                                     } // else loop to get more events
@@ -111,10 +123,15 @@ impl EventDispatcher {
             // Send `batch` events.
             tokio::spawn({
                 let event_delivery = event_delivery.clone();
+                let batch = event_queue.next_batch(QueuedEventStatus::PENDING);
                 async move {
                     // Spawning a new task, so the main task can continue batching events and respond to
                     // commands. At this point, batch_queue is guaranteed to have at least one event.
-                    let result = event_delivery.deliver(batch_queue).await;
+                    let events = batch
+                        .into_iter()
+                        .map(|queued_event| queued_event.event)
+                        .collect();
+                    let result = event_delivery.deliver(events).await;
                     match result {
                         Ok(response) => {
                             if !response.failed_events.is_empty() {
@@ -135,18 +152,19 @@ impl EventDispatcher {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
     use super::*;
+    use crate::events::vec_event_queue::VecEventQueue;
     use crate::timestamp::now;
     use serde::Serialize;
     use serde_json::json;
+    use std::sync::Arc;
     use tokio::sync::mpsc::unbounded_channel;
     use tokio::sync::Mutex;
     use tokio::time::Duration;
     use uuid::Uuid;
-    use wiremock::{MockServer, Mock, ResponseTemplate};
     use wiremock::http::Method;
-    use wiremock::matchers::{method, path, body_json};
+    use wiremock::matchers::{body_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[derive(Debug, Clone, Serialize)]
     struct LoginPayload {
@@ -184,11 +202,10 @@ mod tests {
             retry_interval: Duration::from_millis(1000),
             max_retry_delay: Duration::from_millis(5000),
             max_retries: Some(3),
-            batch_size: 1,
         };
         let (tx, rx) = unbounded_channel();
         let rx = Arc::new(Mutex::new(rx));
-        let dispatcher = EventDispatcher::new(config, tx);
+        let dispatcher = EventDispatcher::new(config, VecEventQueue::new(1, 10), tx);
         dispatcher.dispatch(event).unwrap();
         dispatcher
             .send(EventDispatcherCommand::Flush)
@@ -207,10 +224,10 @@ mod tests {
         let received_requests = mock_server.received_requests().await.unwrap();
         assert_eq!(received_requests.len(), 1);
         let received_request = &received_requests[0];
-        assert_eq!(received_request.method, Method::Post);
+        assert_eq!(received_request.method, Method::POST);
         assert_eq!(received_request.url.path(), "/");
-        let received_body: serde_json::Value = serde_json::from_slice(&received_request.body)
-                .expect("Failed to parse request body");
+        let received_body: serde_json::Value =
+            serde_json::from_slice(&received_request.body).expect("Failed to parse request body");
         assert_eq!(received_body, expected_body);
     }
 }

--- a/eppo_core/src/events/queued_event.rs
+++ b/eppo_core/src/events/queued_event.rs
@@ -1,0 +1,47 @@
+use crate::events::event::Event;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum QueuedEventStatus {
+    PENDING,
+    RETRY,
+    FAILED,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct QueuedEvent {
+    pub event: Event,
+    pub attempts: u8,
+    pub status: QueuedEventStatus,
+}
+
+impl QueuedEvent {
+    pub fn new(event: Event) -> Self {
+        QueuedEvent {
+            event,
+            attempts: 0,
+            status: QueuedEventStatus::PENDING,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::events::event::Event;
+    use crate::events::queued_event::{QueuedEvent, QueuedEventStatus};
+    use crate::timestamp::now;
+
+    #[test]
+    fn test_new() {
+        let event = Event {
+            uuid: uuid::Uuid::new_v4(),
+            timestamp: now(),
+            event_type: "test".to_string(),
+            payload: serde_json::json!({"key": "value"}),
+        };
+        let queued_event = QueuedEvent::new(event.clone());
+        assert_eq!(queued_event.event, event);
+        assert_eq!(queued_event.attempts, 0);
+        assert_eq!(queued_event.event.event_type, "test");
+        assert_eq!(queued_event.status, QueuedEventStatus::PENDING);
+    }
+}

--- a/eppo_core/src/events/queued_event.rs
+++ b/eppo_core/src/events/queued_event.rs
@@ -1,13 +1,13 @@
 use crate::events::event::Event;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum QueuedEventStatus {
-    PENDING,
-    RETRY,
-    FAILED,
+    Pending,
+    Retry,
+    Failed,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct QueuedEvent {
     pub event: Event,
     pub attempts: u8,
@@ -19,7 +19,7 @@ impl QueuedEvent {
         QueuedEvent {
             event,
             attempts: 0,
-            status: QueuedEventStatus::PENDING,
+            status: QueuedEventStatus::Pending,
         }
     }
 }
@@ -42,6 +42,6 @@ mod tests {
         assert_eq!(queued_event.event, event);
         assert_eq!(queued_event.attempts, 0);
         assert_eq!(queued_event.event.event_type, "test");
-        assert_eq!(queued_event.status, QueuedEventStatus::PENDING);
+        assert_eq!(queued_event.status, QueuedEventStatus::Pending);
     }
 }

--- a/eppo_core/src/events/vec_event_queue.rs
+++ b/eppo_core/src/events/vec_event_queue.rs
@@ -1,0 +1,197 @@
+use crate::events::queued_event::{QueuedEvent, QueuedEventStatus};
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+pub trait EventQueue {
+    /// Pushes an event to the end of the queue.
+    fn push(&self, event: QueuedEvent) -> Result<(), QueueError>;
+
+    /// Returns the next batch of events with the provided status.
+    /// and with status PENDING. Events are returned in FIFO order.
+    fn next_batch(&self, status: QueuedEventStatus) -> Vec<QueuedEvent>;
+
+    /// Returns whether the queue contains enough events for delivering *at least* one batch.
+    fn is_batch_full(&self) -> bool;
+}
+
+/// A simple event queue that stores events in a vector
+#[derive(Debug, Clone)]
+pub struct VecEventQueue {
+    batch_size: usize,
+    max_queue_size: usize,
+    event_queue: Arc<Mutex<VecDeque<QueuedEvent>>>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum QueueError {
+    QueueFull,
+}
+
+// batch size of zero means each event will be delivered individually, thus effectively disabling batching.
+const MIN_BATCH_SIZE: usize = 0;
+const MAX_BATCH_SIZE: usize = 10_000;
+
+impl VecEventQueue {
+    pub fn new(batch_size: usize, max_queue_size: usize) -> Self {
+        // clamp batch size between min and max
+        let clamped_batch_size = batch_size.clamp(MIN_BATCH_SIZE, MAX_BATCH_SIZE);
+        VecEventQueue {
+            batch_size: clamped_batch_size,
+            max_queue_size,
+            event_queue: Arc::new(Mutex::new(VecDeque::with_capacity(clamped_batch_size))),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.event_queue.lock().unwrap().len()
+    }
+}
+
+impl EventQueue for VecEventQueue {
+    /// Pushes an event to the end of the queue. If max_queue_size is reached, returns an error instead.
+    fn push(&self, event: QueuedEvent) -> Result<(), QueueError> {
+        if self.len() + 1 > self.max_queue_size {
+            return Err(QueueError::QueueFull);
+        }
+        let mut queue = self.event_queue.lock().unwrap();
+        queue.push_back(event);
+        Ok(())
+    }
+
+    /// Returns up to `batch_size` pending events for delivery from the queue.
+    fn next_batch(&self, status: QueuedEventStatus) -> Vec<QueuedEvent> {
+        let mut batch = Vec::with_capacity(self.batch_size);
+        let mut queue = self.event_queue.lock().unwrap();
+        let mut i = 0;
+        while i < queue.len() && batch.len() < self.batch_size {
+            if queue[i].status == status {
+                batch.push(queue.remove(i).unwrap());
+            } else {
+                i += 1;
+            }
+        }
+
+        batch
+    }
+
+    fn is_batch_full(&self) -> bool {
+        let queue = self.event_queue.lock().unwrap();
+        queue.len() >= self.batch_size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::events::event::Event;
+    use crate::events::queued_event::{QueuedEvent, QueuedEventStatus};
+    use crate::events::vec_event_queue::{EventQueue, QueueError, VecEventQueue, MAX_BATCH_SIZE};
+    use crate::timestamp::now;
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn new_should_clamp_batch_size() {
+        let queue = VecEventQueue::new(300_001, 20);
+        assert_eq!(queue.batch_size, MAX_BATCH_SIZE);
+    }
+
+    #[test]
+    fn test_next_pending_batch() {
+        let queue = VecEventQueue::new(10, 20);
+        assert_eq!(queue.batch_size, 10);
+        assert_eq!(queue.is_batch_full(), false);
+        let events = (0..11)
+            .map(|i| {
+                QueuedEvent::new(Event {
+                    uuid: uuid::Uuid::new_v4(),
+                    timestamp: now(),
+                    event_type: i.to_string(),
+                    payload: serde_json::json!({"key": i.to_string()}),
+                })
+            })
+            .collect::<Vec<_>>();
+        let cloned_events = events.clone();
+        for event in cloned_events {
+            queue.push(event).expect("should not fail");
+        }
+        assert_eq!(queue.is_batch_full(), true);
+        assert_eq!(
+            queue.next_batch(QueuedEventStatus::PENDING),
+            events.into_iter().take(10).collect::<Vec<QueuedEvent>>()
+        );
+        assert_eq!(queue.is_batch_full(), false);
+        assert_eq!(queue.next_batch(QueuedEventStatus::PENDING).len(), 1);
+        assert_eq!(queue.next_batch(QueuedEventStatus::PENDING).len(), 0);
+    }
+
+    #[test]
+    fn test_next_pending_batch_status() {
+        let event_a = Event {
+            uuid: uuid::Uuid::new_v4(),
+            timestamp: now(),
+            event_type: "a".to_string(),
+            payload: serde_json::json!({"key": "value"}),
+        };
+        let event_b = Event {
+            uuid: uuid::Uuid::new_v4(),
+            timestamp: now(),
+            event_type: "b".to_string(),
+            payload: serde_json::json!({"key": "value"}),
+        };
+        let event_c = Event {
+            uuid: uuid::Uuid::new_v4(),
+            timestamp: now(),
+            event_type: "C".to_string(),
+            payload: serde_json::json!({"key": "value"}),
+        };
+        let queued_event_a = QueuedEvent {
+            event: event_a.clone(),
+            attempts: 0,
+            status: QueuedEventStatus::PENDING,
+        };
+        let queued_event_b = QueuedEvent {
+            event: event_b.clone(),
+            attempts: 1,
+            status: QueuedEventStatus::FAILED,
+        };
+        let queued_event_c = QueuedEvent {
+            event: event_c.clone(),
+            attempts: 0,
+            status: QueuedEventStatus::PENDING,
+        };
+        let queue = VecEventQueue {
+            batch_size: 10,
+            max_queue_size: 10,
+            event_queue: Arc::new(Mutex::new(VecDeque::from(vec![
+                queued_event_a.clone(),
+                queued_event_b.clone(),
+                queued_event_c.clone(),
+            ]))),
+        };
+        assert_eq!(
+            queue.next_batch(QueuedEventStatus::PENDING),
+            vec![queued_event_a, queued_event_c]
+        );
+        assert_eq!(
+            queue.next_batch(QueuedEventStatus::FAILED),
+            vec![queued_event_b.clone()]
+        );
+    }
+
+    #[test]
+    fn test_max_queue_size_push() {
+        let queue = VecEventQueue::new(10, 2);
+        let event = QueuedEvent::new(Event {
+            uuid: uuid::Uuid::new_v4(),
+            timestamp: now(),
+            event_type: "test".to_string(),
+            payload: serde_json::json!({"key": "value"}),
+        });
+        queue.push(event.clone()).expect("should not fail");
+        queue.push(event.clone()).expect("should not fail");
+        assert_eq!(
+            queue.push(event.clone()).expect_err("should fail"),
+            QueueError::QueueFull
+        );
+    }
+}

--- a/ruby-sdk/ext/eppo_client/src/configuration.rs
+++ b/ruby-sdk/ext/eppo_client/src/configuration.rs
@@ -87,7 +87,7 @@ impl Configuration {
 
     fn bandits_configuration(ruby: &Ruby, rb_self: &Self) -> Result<Option<RString>, Error> {
         let Some(bandits) = &rb_self.inner.bandits else {
-            return Ok(None)
+            return Ok(None);
         };
         let vec = serde_json::to_vec(bandits).map_err(|err| {
             // this should never happen


### PR DESCRIPTION
## Description

* Add `QueuedEvent` with `status` and `attempts`
* Add `EventQueue` trait and simple `VecEventQueue` implementation
* Write a few more tests
* Allow returning a batch of events with a given status
* Enforce max queue size constraint

## Testing
Wrote tests