### PR TITLE
chore(events): start laying the basis for new design

### DIFF
--- a/eppo_core/src/event_ingestion/auto_flusher.rs
+++ b/eppo_core/src/event_ingestion/auto_flusher.rs
@@ -1,0 +1,45 @@
+use std::time::Duration;
+
+use tokio::{sync::mpsc, time::Instant};
+
+use super::BatchedMessage;
+
+/// Auto-flusher forwards all messages from `uplink` to `downlink` unchanged and inserts extra flush
+/// requests if it hasn't seen one within the given `period`. In other words, it makes sure that the
+/// channel is flushed at least every `period`.
+pub(super) async fn auto_flusher<T>(
+    mut uplink: mpsc::Receiver<BatchedMessage<T>>,
+    downlink: mpsc::Sender<BatchedMessage<T>>,
+    period: Duration,
+) -> Option<()> {
+    'flushed: loop {
+        // Process first message.
+        let msg = uplink.recv().await?;
+        let flushed = msg.flush.is_some();
+        downlink.send(msg).await.ok()?;
+
+        // No need to time if we just flushed.
+        if flushed {
+            continue;
+        }
+
+        let flush_at = Instant::now() + period;
+        // loop till we reach flush_at or see a flushed message.
+        loop {
+            tokio::select! {
+                _ =  tokio::time::sleep_until(flush_at) =>  {
+                    downlink.send(BatchedMessage { batch: Vec::new(), flush: Some(Vec::new()) }).await.ok()?;
+                    continue 'flushed;
+                },
+                msg = uplink.recv() => {
+                    let msg = msg?;
+                    let flushed = msg.flush.is_some();
+                    downlink.send(msg).await.ok()?;
+                    if flushed {
+                        continue 'flushed;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/eppo_core/src/event_ingestion/batched_message.rs
+++ b/eppo_core/src/event_ingestion/batched_message.rs
@@ -1,0 +1,31 @@
+/// Batched message contain a batch of data and may optionally require processors to flush any processing.
+#[derive(Debug)]
+pub(super) struct BatchedMessage<T> {
+    pub batch: Vec<T>,
+    /// `None` means the message does not require a flush.
+    /// `Some` contains a list of watchers.
+    pub flush: Option<Vec<tokio::sync::oneshot::Sender<()>>>,
+}
+
+impl<T> BatchedMessage<T> {
+    /// Create a new empty message.
+    pub fn empty() -> BatchedMessage<T> {
+        BatchedMessage {
+            batch: Vec::new(),
+            flush: None,
+        }
+    }
+
+    pub fn requires_flush(&self) -> bool {
+        self.flush.is_some()
+    }
+
+    /// Mark the message as successfully flushed, consuming it and notifying any interested parties.
+    pub fn flushed(self) {
+        if let Some(flush) = self.flush {
+            for f in flush {
+                f.send(());
+            }
+        }
+    }
+}

--- a/eppo_core/src/event_ingestion/batcher.rs
+++ b/eppo_core/src/event_ingestion/batcher.rs
@@ -1,0 +1,38 @@
+use tokio::sync::mpsc;
+
+use super::BatchedMessage;
+
+/// Batch messages, so they are at least `min_batch_size` size. Push incomplete batch down if flush
+/// is received.
+///
+/// If uplink is closed, send all buffered data downstream and exit.
+///
+/// If downlink is closed, just exit.
+pub(super) async fn batcher<T>(
+    mut uplink: mpsc::Receiver<BatchedMessage<T>>,
+    downlink: mpsc::Sender<BatchedMessage<T>>,
+    min_batch_size: usize,
+) -> Option<()> {
+    let mut uplink_alive = true;
+    while uplink_alive {
+        let mut batch = BatchedMessage::empty();
+
+        while uplink_alive && batch.batch.len() < min_batch_size && batch.flush.is_none() {
+            match uplink.recv().await {
+                None => {
+                    uplink_alive = false;
+                }
+                Some(BatchedMessage {
+                    batch: events,
+                    flush,
+                }) => {
+                    batch.batch.extend(events);
+                    batch.flush = flush;
+                }
+            }
+        }
+
+        downlink.send(batch).await.ok()?;
+    }
+    None
+}

--- a/eppo_core/src/event_ingestion/delivery.rs
+++ b/eppo_core/src/event_ingestion/delivery.rs
@@ -1,0 +1,15 @@
+use tokio::sync::mpsc;
+
+use super::{BatchedMessage, Event};
+
+pub(super) struct DeliveryStatus {
+    success: Vec<Event>,
+    failure: Vec<Event>,
+}
+
+pub(super) async fn delivery(
+    mut uplink: mpsc::Receiver<BatchedMessage<Event>>,
+    delivery_status: mpsc::Sender<DeliveryStatus>,
+    // TODO: configuration
+) {
+}

--- a/eppo_core/src/event_ingestion/event.rs
+++ b/eppo_core/src/event_ingestion/event.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+use crate::timestamp::Timestamp;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+pub(super) struct Event {
+    pub uuid: uuid::Uuid,
+    pub timestamp: Timestamp,
+    pub event_type: String,
+    pub payload: serde_json::Value,
+}

--- a/eppo_core/src/event_ingestion/mod.rs
+++ b/eppo_core/src/event_ingestion/mod.rs
@@ -1,5 +1,8 @@
 mod auto_flusher;
 mod batched_message;
 mod batcher;
+mod delivery;
+mod event;
 
 use batched_message::BatchedMessage;
+use event::Event;

--- a/eppo_core/src/event_ingestion/mod.rs
+++ b/eppo_core/src/event_ingestion/mod.rs
@@ -1,0 +1,5 @@
+mod auto_flusher;
+mod batched_message;
+mod batcher;
+
+use batched_message::BatchedMessage;

--- a/eppo_core/src/lib.rs
+++ b/eppo_core/src/lib.rs
@@ -69,6 +69,8 @@ mod precomputed;
 mod sdk_metadata;
 mod str;
 
+mod event_ingestion;
+
 pub use crate::str::Str;
 pub use attributes::{
     AttributeValue, Attributes, CategoricalAttribute, ContextAttributes, NumericAttribute,


### PR DESCRIPTION
Wrapping up for today and didn't have much time to push buttons but wanted to lay out the basis for my proposed design

- Added batcher and auto-flusher components
- Defined the interface for the delivery component
- Decided to move to a new directory to not clash with other implementation but also because it's a separate feature from assignment/bandit events

@felipecsl I propose that you continue with the delivery component and I'll work on the persistent queue. We also need a bit more glue code to connect components and run them all on tokio.