### PR TITLE
add `sync` flag for `tokio` dependency

### DIFF
--- a/.changeset/loud-parents-leave.md
+++ b/.changeset/loud-parents-leave.md
@@ -1,0 +1,5 @@
+---
+"eppo_core": patch
+---
+
+add sync feature to tokio crate

--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -36,13 +36,13 @@ serde-bool = "0.1.3"
 serde_json = "1.0.116"
 serde_with = { version = "3.11.0", default-features = false, features = ["base64", "hex", "macros"] }
 thiserror = "2.0.3"
-tokio = { version = "1.34.0", features = ["rt", "time", "macros"] }
+tokio = { version = "1.34.0", features = ["macros", "sync", "rt", "time"] }
 url = "2.5.0"
 uuid = { version = "1.11.0", features = ["v4", "serde"] }
 
 # pyo3 dependencies
 pyo3 = { version = "0.22.0", optional = true, default-features = false }
-serde-pyobject = { version = "0.4.0", optional = true}
+serde-pyobject = { version = "0.4.0", optional = true }
 
 # magnus dependencies
 magnus = { version = "0.6.4", default-features = false, optional = true }


### PR DESCRIPTION
## Motivation

When going from `eppo_core 6.0.0->7.0.0` in the precompute server this error was thrown:

```
   Updating crates.io index
     Locking 2 packages to latest compatible versions
    Updating eppo_core v6.0.0 -> v7.0.0
      Adding tokio-macros v2.4.0 (available: v2.5.0)
  Downloaded eppo_core v7.0.0
  Downloaded 1 crate (66.1 KB) in 0.38s
   Compiling tokio-macros v2.4.0
   Compiling uuid v1.11.0
warning: the `wasm32-wasi` target is being renamed to `wasm32-wasip1` and the `wasm32-wasi` target will be removed from nightly in October 2024 and removed from stable Rust in January 2025

warning: `uuid` (lib) generated 1 warning
   Compiling tokio v1.42.0
   Compiling eppo_core v7.0.0
warning: `tokio` (lib) generated 1 warning (1 duplicate)
error[E0432]: unresolved import `tokio::sync::mpsc`
   --> /Users/leo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/eppo_core-7.0.0/src/events/event_dispatcher.rs:3:18
    |
3   | use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiv...
    |                  ^^^^ could not find `mpsc` in `sync`
    |
note: found an item that was configured out
   --> /Users/leo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.42.0/src/sync/mod.rs:460:13
    |
460 |     pub mod mpsc;
    |             ^^^^
note: the item is gated behind the `sync` feature
   --> /Users/leo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.42.0/src/sync/mod.rs:449:1
    |
449 | / cfg_sync! {
450 | |     /// Named future types.
451 | |     pub mod futures {
452 | |         pub use super::notify::Notified;
...   |
491 | |     pub mod watch;
492 | | }
    | |_^
    = note: this error originates in the macro `cfg_sync` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0603]: module `sync` is private
   --> /Users/leo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/eppo_core-7.0.0/src/events/event_dispatcher.rs:3:12
    |
3   | use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiv...
    |            ^^^^ private module
    |
note: the module `sync` is defined here
   --> /Users/leo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.42.0/src/lib.rs:547:5
    |
547 |     mod sync;
    |     ^^^^^^^^

Some errors have detailed explanations: E0432, E0603.
For more information about an error, try `rustc --explain E0432`.
warning: `eppo_core` (lib) generated 1 warning (1 duplicate)
error: could not compile `eppo_core` (lib) due to 2 previous errors; 1 warning emitted
```

TIL - you can use parts of crate dependencies without the flag. This makes these kind of problems upstream more likely, which is unfortunate.

## Description

I have added the `sync` flag to `tokio` - this is the most straight-forward resolution.

Also considered whether we want to publish our own flag for `eppo_core` and gate the event logger modules - that way for example the precompute server can avoid pulling them in. Our project is still nascent and I didn't want to add that complication yet.