### PR TITLE
chore: fix typo in publish.yml update_ruby_lockfile step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
 
   update_ruby_lockfile:
     name: Update Ruby SDK lockfile
-    run-on: ubuntu-latest
+    runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref_name, 'eppo_core@') }}
     needs: publish
     steps:


### PR DESCRIPTION
## motivation

error thrown:

```
[Invalid workflow file: .github/workflows/publish.yml#L60](https://github.com/Eppo-exp/eppo-multiplatform/actions/runs/12834205830/workflow)
The workflow is not valid. .github/workflows/publish.yml (Line: 60, Col: 5): Unexpected value 'run-on' .github/workflows/publish.yml (Line: 59, Col: 5): Required property is missing: runs-on
```

https://github.com/Eppo-exp/eppo-multiplatform/actions/runs/12834205830