### PR TITLE
chore: disconnect SDK releases from eppo_core

### DIFF
--- a/python-sdk/package.json
+++ b/python-sdk/package.json
@@ -3,7 +3,6 @@
   "name": "python-sdk",
   "version": "4.2.2",
   "dependencies": {
-    "eppo_core": "7.0.2"
   },
   "devDependencies": {},
   "scripts": {

--- a/ruby-sdk/package.json
+++ b/ruby-sdk/package.json
@@ -3,7 +3,6 @@
   "name": "ruby-sdk",
   "version": "3.4.2",
   "dependencies": {
-    "eppo_core": "7.0.2"
   },
   "devDependencies": {},
   "scripts": {

--- a/rust-sdk/package.json
+++ b/rust-sdk/package.json
@@ -3,7 +3,6 @@
   "name": "rust-sdk",
   "version": "5.0.2",
   "dependencies": {
-    "eppo_core": "7.0.2"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Currently, every change to eppo_core causes a patch version bump and new release for every SDK.

This is somewhat undesirable because changes to eppo_core don't always translate to something meaningful changing in SDKs. Or sometimes, nothing changes at all (e.g., updating pyo3 in eppo_core does not change *anything* for Ruby/Rust SDKs).

I figured that removing eppo_core from dependencies of SDKs should allow us versioning all packages independently. Real dependency version is still bumped from eppo_core's postversion.sh, so this shouldn't change that. But it will allow us to push changes to core that don't cause release of SDKs.

When we want to trigger an SDK release, we should bump it's patch version via a changeset explicitly.

This PR also gets rid of useless "Updated dependencies: eppo_core" in changelogs. (These don't tell anything important to SDK users.)