### PR TITLE
chore(events): Enforce max event serialized length

### DIFF
--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -10,7 +10,6 @@ categories = ["config"]
 rust-version = "1.75.0"
 
 [features]
-default = ["event_ingestion"]
 # Unstable feature flag for an upcoming feature.
 event_ingestion = ["dep:uuid", "dep:exponential-backoff"]
 # Add implementation of `FromPyObject`/`ToPyObject` for some types.

--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["config"]
 rust-version = "1.75.0"
 
 [features]
+default = ["event_ingestion"]
 # Unstable feature flag for an upcoming feature.
 event_ingestion = ["dep:uuid", "dep:exponential-backoff"]
 # Add implementation of `FromPyObject`/`ToPyObject` for some types.

--- a/eppo_core/src/event_ingestion/delivery.rs
+++ b/eppo_core/src/event_ingestion/delivery.rs
@@ -1,6 +1,6 @@
 use super::BatchedMessage;
 use crate::event_ingestion::event_delivery::{
-    EventDelivery, EventDeliveryError, EventDeliveryResponse,
+    EventDelivery, EventDeliveryError, DeliveryResult,
 };
 use crate::event_ingestion::queued_event::QueuedEvent;
 use log::warn;
@@ -96,14 +96,14 @@ pub(super) async fn delivery(
 
 fn collect_delivery_response(
     batch: Vec<QueuedEvent>,
-    response: EventDeliveryResponse,
+    result: DeliveryResult,
     max_retries: u32,
 ) -> QueuedBatch {
-    if response.is_empty() {
+    if result.is_empty() {
         return QueuedBatch::success(batch);
     }
-    let failed_retriable_event_uuids = response.retriable_failed_events;
-    let failed_non_retriable_event_uuids = response.non_retriable_failed_events;
+    let failed_retriable_event_uuids = result.retriable_failed_events;
+    let failed_non_retriable_event_uuids = result.non_retriable_failed_events;
     warn!("Failed to deliver {} events (retriable)", failed_retriable_event_uuids.len());
     let mut success = Vec::new();
     let mut failure = Vec::new();

--- a/eppo_core/src/event_ingestion/delivery.rs
+++ b/eppo_core/src/event_ingestion/delivery.rs
@@ -80,12 +80,13 @@ pub(super) async fn delivery(
                 match err {
                     EventDeliveryError::RetriableError(_) => {
                         // Retry later
-                        deliver_status(&delivery_status, QueuedBatch::failure(batch)).await;
+                        deliver_status(&delivery_status, QueuedBatch::retry(batch)).await;
                     }
-                    EventDeliveryError::NonRetriableError(_) => {
+                    _ => {
                         warn!("Failed to deliver events: {}", err);
                         // In this case there is no point in retrying delivery since the error is
                         // non-retriable.
+                        deliver_status(&delivery_status, QueuedBatch::failure(batch)).await;
                     }
                 }
             }

--- a/eppo_core/src/event_ingestion/event_delivery.rs
+++ b/eppo_core/src/event_ingestion/event_delivery.rs
@@ -1,4 +1,5 @@
 use crate::event_ingestion::event::Event;
+use crate::event_ingestion::event_delivery::EventDeliveryError::{EventPayloadTooLargeError, JsonSerializationError};
 use crate::Str;
 use log::{debug, info};
 use reqwest::StatusCode;
@@ -7,6 +8,8 @@ use std::collections::HashSet;
 use url::Url;
 use uuid::Uuid;
 
+const MAX_EVENT_SERIALIZED_LENGTH: usize = 4096;
+
 #[derive(Clone)]
 pub(super) struct EventDelivery {
     sdk_key: Str,
@@ -14,13 +17,17 @@ pub(super) struct EventDelivery {
     client: reqwest::Client,
 }
 
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, Debug)]
 pub(super) struct EventDeliveryResponse {
     pub failed_events: HashSet<Uuid>,
 }
 
 #[derive(thiserror::Error, Debug)]
 pub(super) enum EventDeliveryError {
+    #[error("Single event payload too large {0} (expected < {max})", max = MAX_EVENT_SERIALIZED_LENGTH)]
+    EventPayloadTooLargeError(usize),
+    #[error("Failed to serialize events to JSON")]
+    JsonSerializationError(serde_json::Error),
     #[error("Transient error delivering events")]
     RetriableError(reqwest::Error),
     #[error("Non-retriable error")]
@@ -51,14 +58,17 @@ impl EventDelivery {
         let ingestion_url = self.ingestion_url.clone();
         let sdk_key = &self.sdk_key;
         debug!("Delivering {} events to {}", events.len(), ingestion_url);
-        let body = IngestionRequestBody {
-            eppo_events: events,
-        };
+        for event in &events {
+            ensure_max_event_size(&event)?;
+        }
+        let body = IngestionRequestBody { eppo_events: events };
+        let serialized_body = serde_json::to_vec(&body)
+            .map_err(|e| JsonSerializationError(e))?;
         let response = self
             .client
             .post(ingestion_url)
             .header("X-Eppo-Token", sdk_key.as_str())
-            .json(&body)
+            .body(serialized_body)
             .send()
             .await
             .map_err(EventDeliveryError::RetriableError)?;
@@ -86,5 +96,76 @@ impl EventDelivery {
             response.failed_events.len()
         );
         Ok(response)
+    }
+}
+
+fn ensure_max_event_size(event: &Event) -> Result<(), EventDeliveryError> {
+    let serialized_event = serde_json::to_vec(event)
+        .map_err(|e| JsonSerializationError(e))?;
+    if serialized_event.len() > MAX_EVENT_SERIALIZED_LENGTH {
+        Err(EventPayloadTooLargeError(serialized_event.len()))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::event_ingestion::event::Event;
+    use crate::event_ingestion::event_delivery::EventDeliveryError::EventPayloadTooLargeError;
+    use crate::event_ingestion::event_delivery::{EventDelivery, MAX_EVENT_SERIALIZED_LENGTH};
+    use crate::timestamp::now;
+    use crate::Str;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use url::Url;
+    use uuid::Uuid;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Test that an event over-4096-byte serialized length triggers a EventPayloadTooLargeError.
+    #[tokio::test]
+    async fn test_deliver_fails_on_large_payload() {
+        let client = EventDelivery::new(Str::from("foobar"), Url::parse("https://example.com").unwrap());
+        // Create an event that will produce a large JSON string.
+        // Just repeat "A" enough times that JSON definitely exceeds 4096 bytes.
+        let huge_string = "A".repeat(MAX_EVENT_SERIALIZED_LENGTH + 1);
+        let large_event = new_test_event(huge_string);
+        let events = vec![large_event];
+        let result = client.deliver(events).await;
+        // We expect a NonRetriableError because the payload is too large
+        assert!(matches!(result, Err(EventPayloadTooLargeError(_))));
+    }
+
+    /// Test that an event serialized size **just** under 4096 bytes succeeds.
+    #[tokio::test]
+    async fn test_deliver_succeeds_on_small_payload() {
+        let response_body = ResponseTemplate::new(200).set_body_json(json!({"failed_events": []}));
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(response_body)
+            .mount(&mock_server)
+            .await;
+        let client = EventDelivery::new(Str::from("foobar"), Url::parse(mock_server.uri().as_str()).unwrap());
+        let small_event = new_test_event("A".repeat(3500));
+        let events = vec![small_event];
+        let result = client.deliver(events).await;
+        // Should be ok because payload is not over MAX_EVENT_PAYLOAD_SIZE
+        assert!(result.is_ok(), "Expected Ok, got {:?}", result);
+    }
+
+    fn new_test_event(user_id: String) -> Event {
+        let payload: HashMap<&str, String> = HashMap::from([
+            ("user_id", user_id),
+            ("session_id", "session456".to_string()),
+        ]);
+        let serialized_payload = serde_json::to_value(payload).expect("Serialization failed");
+        Event {
+            uuid: Uuid::new_v4(),
+            timestamp: now(),
+            event_type: "test".to_string(),
+            payload: serialized_payload,
+        }
     }
 }

--- a/eppo_core/src/event_ingestion/event_dispatcher.rs
+++ b/eppo_core/src/event_ingestion/event_dispatcher.rs
@@ -44,8 +44,6 @@ impl EventDispatcher {
         let ingestion_url = Url::parse(config.ingestion_url.as_str())
             .expect("Failed to create EventDelivery. invalid ingestion URL");
         let event_delivery = EventDelivery::new(config.sdk_key.into(), ingestion_url);
-
-        let channel_size = config.max_queue_size;
         let (sender, flusher_uplink_rx) = mpsc::channel(config.max_queue_size);
         let (flusher_downlink_tx, flusher_downlink_rx) = mpsc::channel(1);
         let (batcher_downlink_tx, batcher_downlink_rx) = mpsc::channel(1);


### PR DESCRIPTION
Fixes FF-3849

## Description

Enforce that each event's serialized JSON string is under 4096 bytes.

## Testing

Wrote tests