### PR TITLE
chore(events): Send only retriable events to `retry` component

### DIFF
--- a/eppo_core/src/event_ingestion/event_delivery.rs
+++ b/eppo_core/src/event_ingestion/event_delivery.rs
@@ -1,11 +1,11 @@
 use crate::event_ingestion::event::Event;
 use crate::event_ingestion::event_delivery::EventDeliveryError::{
-    EventPayloadTooLargeError, JsonDeserializationError, JsonSerializationError,
+    JsonDeserializationError, JsonSerializationError,
 };
 use crate::Str;
 use log::{debug, info};
 use reqwest::StatusCode;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::collections::HashSet;
 use url::Url;
 use uuid::Uuid;

--- a/eppo_core/src/event_ingestion/event_dispatcher.rs
+++ b/eppo_core/src/event_ingestion/event_dispatcher.rs
@@ -48,7 +48,7 @@ impl EventDispatcher {
         let (flusher_downlink_tx, flusher_downlink_rx) = mpsc::channel(1);
         let (batcher_downlink_tx, batcher_downlink_rx) = mpsc::channel(1);
         let (delivery_downlink_tx, delivery_downlink_rx) = mpsc::channel(1);
-        let (retry_downlink_tx, receiver) = mpsc::channel(1);
+        let (output_tx, receiver) = mpsc::channel(1);
 
         // Spawn the auto_flusher, batcher and delivery
         tokio::spawn(auto_flusher::auto_flusher(
@@ -64,13 +64,14 @@ impl EventDispatcher {
         tokio::spawn(delivery::delivery(
             batcher_downlink_rx,
             delivery_downlink_tx,
+            output_tx.clone(),
             config.max_retries,
             event_delivery,
         ));
         tokio::spawn(retry::retry(
             delivery_downlink_rx,
             batcher_downlink_tx,
-            retry_downlink_tx,
+            output_tx,
             config.max_retries as u32,
             config.retry_interval,
             config.max_retry_delay,


### PR DESCRIPTION
## Description

Addressing feedback here https://github.com/Eppo-exp/eppo-multiplatform/pull/158#discussion_r1926872837 from @rasendubi 

## Testing

Existing tests