### PR TITLE
chore(ci): add missing semicolon 🤦 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -197,7 +197,7 @@ jobs:
         run: |
           gem install pkg/eppo-server-sdk-*.gem --verbose
           script="EppoClient::init(EppoClient::Config.new('placeholder')); EppoClient::Client.instance.shutdown"
-          ruby -reppo_client -e "$script" 2>&1 || { echo "❌ Failed to run smoke test"; exit 1 }
+          ruby -reppo_client -e "$script" 2>&1 || { echo "❌ Failed to run smoke test"; exit 1; }
           echo "✅ Successfully installed gem"
         env:
           EPPO_LOG: "eppo=debug"


### PR DESCRIPTION
Without the semicolon after `exit 1`, the shell interprets `}` as a second argument of `exit` and then fails to parse the shell file because it cannot find a closing brace.