### PR TITLE
fix(events): Ensure Event timestamp is sent as epoch milliseconds

### DIFF
--- a/.changeset/moody-lions-approve.md
+++ b/.changeset/moody-lions-approve.md
@@ -1,0 +1,6 @@
+---
+"eppo_core": patch
+"ruby-sdk": patch
+---
+
+[Unstable] Event Ingestion: Fix JSON serialization of Event timestamp field

--- a/eppo_core/src/event_ingestion/event.rs
+++ b/eppo_core/src/event_ingestion/event.rs
@@ -1,11 +1,39 @@
 use crate::timestamp::Timestamp;
-use serde::{Deserialize, Serialize};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize, Serializer};
+use serde::de::Deserializer;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub(super) struct Event {
     pub uuid: uuid::Uuid,
+    #[serde(
+        serialize_with = "serialize_millis",
+        deserialize_with = "deserialize_millis"
+    )]
     pub timestamp: Timestamp,
     #[serde(rename = "type")]
     pub event_type: String,
     pub payload: serde_json::Value,
+}
+
+fn serialize_millis<S>(date: &Timestamp, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    // Convert to i64 representing milliseconds since the Unix epoch
+    let millis = date.timestamp_millis();
+    serializer.serialize_i64(millis)
+}
+
+fn deserialize_millis<'de, D>(deserializer: D) -> Result<Timestamp, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let millis = i64::deserialize(deserializer)?;
+    // Convert i64 millis back to Timestamp
+    let secs = millis / 1000;
+    let subsec_nanos = ((millis % 1000) * 1_000_000) as u32;
+    let naive = DateTime::from_timestamp(secs, subsec_nanos)
+        .ok_or_else(|| serde::de::Error::custom("Invalid timestamp"))?;
+    Ok(Timestamp::from(naive))
 }

--- a/eppo_core/src/event_ingestion/event.rs
+++ b/eppo_core/src/event_ingestion/event.rs
@@ -1,7 +1,7 @@
 use crate::timestamp::Timestamp;
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize, Serializer};
 use serde::de::Deserializer;
+use serde::{Deserialize, Serialize, Serializer};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub(super) struct Event {

--- a/eppo_core/src/event_ingestion/event.rs
+++ b/eppo_core/src/event_ingestion/event.rs
@@ -1,39 +1,18 @@
-use crate::timestamp::Timestamp;
-use chrono::{DateTime, Utc};
-use serde::de::Deserializer;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
+use crate::timestamp::Timestamp;
+
+#[serde_as]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub(super) struct Event {
     pub uuid: uuid::Uuid,
-    #[serde(
-        serialize_with = "serialize_millis",
-        deserialize_with = "deserialize_millis"
-    )]
+
+    #[serde(with = "chrono::serde::ts_milliseconds")]
     pub timestamp: Timestamp,
+
     #[serde(rename = "type")]
     pub event_type: String,
+
     pub payload: serde_json::Value,
-}
-
-fn serialize_millis<S>(date: &Timestamp, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    // Convert to i64 representing milliseconds since the Unix epoch
-    let millis = date.timestamp_millis();
-    serializer.serialize_i64(millis)
-}
-
-fn deserialize_millis<'de, D>(deserializer: D) -> Result<Timestamp, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let millis = i64::deserialize(deserializer)?;
-    // Convert i64 millis back to Timestamp
-    let secs = millis / 1000;
-    let subsec_nanos = ((millis % 1000) * 1_000_000) as u32;
-    let naive = DateTime::from_timestamp(secs, subsec_nanos)
-        .ok_or_else(|| serde::de::Error::custom("Invalid timestamp"))?;
-    Ok(Timestamp::from(naive))
 }

--- a/eppo_core/src/event_ingestion/event_delivery.rs
+++ b/eppo_core/src/event_ingestion/event_delivery.rs
@@ -183,7 +183,7 @@ mod tests {
             .and(body_json(&json!({
                 "eppo_events": [{
                     "uuid": uuid,
-                    "timestamp": timestamp,
+                    "timestamp": timestamp.timestamp_millis(),
                     "type": "test",
                     "payload": {
                         "user_id": "user123",

--- a/eppo_core/src/lib.rs
+++ b/eppo_core/src/lib.rs
@@ -56,12 +56,12 @@ pub mod configuration_fetcher;
 pub mod configuration_poller;
 pub mod configuration_store;
 pub mod eval;
-mod sdk_key;
 #[cfg(feature = "event_ingestion")]
 pub mod event_ingestion;
 pub mod events;
 #[cfg(feature = "pyo3")]
 pub mod pyo3;
+mod sdk_key;
 pub mod sharder;
 pub mod timestamp;
 pub mod ufc;

--- a/eppo_core/src/lib.rs
+++ b/eppo_core/src/lib.rs
@@ -61,7 +61,6 @@ pub mod event_ingestion;
 pub mod events;
 #[cfg(feature = "pyo3")]
 pub mod pyo3;
-mod sdk_key;
 pub mod sharder;
 pub mod timestamp;
 pub mod ufc;
@@ -70,6 +69,7 @@ mod configuration;
 mod error;
 mod obfuscation;
 mod precomputed;
+mod sdk_key;
 mod sdk_metadata;
 mod str;
 


### PR DESCRIPTION
## Description

Event timestamp field should be sent as epoch milliseconds numeric value instead of datetime string.

## Testing

Wrote a test

FF-3962