### PR TITLE
ci: Add path filtering to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,21 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'rust-sdk/**'
+      - 'eppo_core/**'
+      - 'sdk-test-data/**'
+      - 'mock-server/**'
+      - 'package-lock.json'
+      - 'package.json'
   pull_request:
+    paths:
+      - 'rust-sdk/**'
+      - 'eppo_core/**'
+      - 'sdk-test-data/**'
+      - 'mock-server/**'
+      - 'package-lock.json'
+      - 'package.json'
   workflow_call:
     inputs:
       test_data_branch:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,9 +13,23 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'python-sdk/**'
+      - 'eppo_core/**'
+      - 'sdk-test-data/**'
+      - 'mock-server/**'
+      - 'package-lock.json'
+      - 'package.json'
   release:
     types: [published]
   pull_request:
+    paths:
+      - 'python-sdk/**'
+      - 'eppo_core/**'
+      - 'sdk-test-data/**'
+      - 'mock-server/**'
+      - 'package-lock.json'
+      - 'package.json'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,7 +5,21 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'ruby-sdk/**'
+      - 'eppo_core/**'
+      - 'sdk-test-data/**'
+      - 'mock-server/**'
+      - 'package-lock.json'
+      - 'package.json'
   pull_request:
+    paths:
+      - 'ruby-sdk/**'
+      - 'eppo_core/**'
+      - 'sdk-test-data/**'
+      - 'mock-server/**'
+      - 'package-lock.json'
+      - 'package.json'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
No need to run, say, Python SDK tests, when making changes to the Ruby SDK. This update limits CI workflows to run only when there are relevant changes. 