### PR TITLE
fix(python): Options that are None are also None in python

### DIFF
--- a/.changeset/cyan-socks-fold.md
+++ b/.changeset/cyan-socks-fold.md
@@ -1,8 +1,8 @@
 ---
 "eppo_core": patch
 "python-sdk": patch
+"ruby-sdk": patch
+"rust-sdk": patch
 ---
 
-fix(python): Options that are None are also None in python
-
-None Attributes are now correctly converted to Python's `None` instead of `()` empty tuple.
+Fix `AttributeValue` serialization, so `Null` attributes are properly serialized as None instead of unit value.

--- a/.changeset/cyan-socks-fold.md
+++ b/.changeset/cyan-socks-fold.md
@@ -1,0 +1,8 @@
+---
+"eppo_core": patch
+"python-sdk": patch
+---
+
+fix(python): Options that are None are also None in python
+
+None Attributes are now correctly converted to Python's `None` instead of `()` empty tuple.

--- a/eppo_core/src/attributes.rs
+++ b/eppo_core/src/attributes.rs
@@ -35,7 +35,7 @@ pub type Attributes = HashMap<Str, AttributeValue>;
 #[derive(Debug, Clone, PartialEq, PartialOrd, derive_more::From, Serialize, Deserialize)]
 #[from(NumericAttribute, CategoricalAttribute, f64, bool, Str, String, &str, Arc<str>, Arc<String>, Cow<'_, str>)]
 pub struct AttributeValue(AttributeValueImpl);
-#[derive(Debug, Clone, PartialEq, PartialOrd, derive_more::From, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, derive_more::From, Deserialize)]
 #[serde(untagged)]
 enum AttributeValueImpl {
     #[from(NumericAttribute, f64)]
@@ -44,6 +44,23 @@ enum AttributeValueImpl {
     Categorical(CategoricalAttribute),
     #[from(ignore)]
     Null,
+}
+
+impl serde::Serialize for AttributeValueImpl {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            AttributeValueImpl::Numeric(numeric_attribute) => {
+                numeric_attribute.serialize(serializer)
+            }
+            AttributeValueImpl::Categorical(categorical_attribute) => {
+                categorical_attribute.serialize(serializer)
+            }
+            AttributeValueImpl::Null => serializer.serialize_none(),
+        }
+    }
 }
 
 impl AttributeValue {

--- a/eppo_core/src/pyo3.rs
+++ b/eppo_core/src/pyo3.rs
@@ -25,7 +25,7 @@ impl<T: TryToPyObject> TryToPyObject for Option<T> {
     fn try_to_pyobject(&self, py: Python) -> PyResult<PyObject> {
         match self {
             Some(it) => it.try_to_pyobject(py),
-            None => Ok(().to_object(py)),
+            None => Ok(py.None()),
         }
     }
 }

--- a/python-sdk/tests/test_assignment_logger.py
+++ b/python-sdk/tests/test_assignment_logger.py
@@ -41,7 +41,7 @@ def test_event_format():
 
     client = init("ufc", assignment_logger=MyAssignmentLogger())
     result = client.get_string_assignment(
-        "regex-flag", "alice", {"email": "alice@example.com"}, "default"
+        "regex-flag", "alice", {"email": "alice@example.com", "empty": None}, "default"
     )
     assert result == "partial-example"
 
@@ -49,3 +49,5 @@ def test_event_format():
     assert event["featureFlag"] == "regex-flag"
     assert event["experiment"] == "regex-flag-partial-example"
     assert event["metaData"]["sdkName"] == "python"
+    assert event["subjectAttributes"]["email"] == "alice@example.com"
+    assert event["subjectAttributes"]["empty"] is None


### PR DESCRIPTION
## Description

Options that are `None` in rust are also `None` in python instead of empty tuples. 

Currently when it is converted back to python it ends up as tuple `()`  which will create an empty tuple object instead. 

## Testing

Updated test to include checking conversion. 

## References 

fixes: https://github.com/Eppo-exp/eppo-multiplatform/issues/211
