### PR TITLE
chore(core): bump MSRV to 1.80.0

### DIFF
--- a/.changeset/selfish-houses-doubt.md
+++ b/.changeset/selfish-houses-doubt.md
@@ -1,0 +1,8 @@
+---
+"eppo_core": patch
+"rust-sdk": patch
+"ruby-sdk": patch
+"python-sdk": patch
+---
+
+Bump Minimum Supported Rust Version (MSRV) to 1.80.0.

--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/Eppo-exp/rust-sdk"
 license = "MIT"
 keywords = ["eppo", "feature-flags"]
 categories = ["config"]
-rust-version = "1.75.0"
+rust-version = "1.80.0"
 
 [features]
 # Unstable feature flag for an upcoming feature.

--- a/eppo_core/src/configuration.rs
+++ b/eppo_core/src/configuration.rs
@@ -76,13 +76,11 @@ impl Configuration {
     /// initialization.
     pub fn get_bandits_configuration(&self) -> Option<Cow<[u8]>> {
         let bandits = self.bandits.as_ref()?;
-        let json = serde_json::to_vec(bandits);
-
-        // TODO: replace with .inspect_err() once we bump MSRV to 1.76
-        if let Err(err) = &json {
-            log::warn!(target: "eppo", "failed to serialize bandits: {err:?}");
-        }
-
-        json.ok().map(Cow::Owned)
+        serde_json::to_vec(bandits)
+            .inspect_err(|err| {
+                log::warn!(target: "eppo", "failed to serialize bandits: {err:?}");
+            })
+            .ok()
+            .map(Cow::Owned)
     }
 }

--- a/ruby-sdk/ext/eppo_client/Cargo.toml
+++ b/ruby-sdk/ext/eppo_client/Cargo.toml
@@ -5,7 +5,7 @@ version = "3.4.5"
 edition = "2021"
 license = "MIT"
 publish = false
-rust-version = "1.75.0"
+rust-version = "1.80.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/rust-sdk/Cargo.toml
+++ b/rust-sdk/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/Eppo-exp/rust-sdk"
 license = "MIT"
 keywords = ["eppo", "feature-flags"]
 categories = ["config"]
-rust-version = "1.75.0"
+rust-version = "1.80.0"
 
 [dependencies]
 eppo_core = { version = "=8.0.2", path = "../eppo_core" }


### PR DESCRIPTION
CI is currently failing because native-tls bumped their MSRV to 1.80.0. Follow them to unblock CI.