### PR TITLE
temporarily disable msrv check

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,10 +1,12 @@
 name: Verify MSRV version
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  # Temporarily disabled automatic triggers
+  # push:
+  #   branches:
+  #     - main
+  # pull_request:
+  workflow_dispatch: # Can be manually triggered if needed
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
The MSRV check is failing in all branches.

We agreed to temporarily disable this while we rework the rust version we build with.