### PR TITLE
chore(ci): fix CI not triggering on sdk-test-data update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - 'rust-sdk/**'
       - 'eppo_core/**'
-      - 'sdk-test-data/**'
+      - 'sdk-test-data'
       - 'mock-server/**'
       - 'package-lock.json'
       - 'package.json'
@@ -15,7 +15,7 @@ on:
     paths:
       - 'rust-sdk/**'
       - 'eppo_core/**'
-      - 'sdk-test-data/**'
+      - 'sdk-test-data'
       - 'mock-server/**'
       - 'package-lock.json'
       - 'package.json'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,7 +16,7 @@ on:
     paths:
       - 'python-sdk/**'
       - 'eppo_core/**'
-      - 'sdk-test-data/**'
+      - 'sdk-test-data'
       - 'mock-server/**'
       - 'package-lock.json'
       - 'package.json'
@@ -26,7 +26,7 @@ on:
     paths:
       - 'python-sdk/**'
       - 'eppo_core/**'
-      - 'sdk-test-data/**'
+      - 'sdk-test-data'
       - 'mock-server/**'
       - 'package-lock.json'
       - 'package.json'

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - 'ruby-sdk/**'
       - 'eppo_core/**'
-      - 'sdk-test-data/**'
+      - 'sdk-test-data'
       - 'mock-server/**'
       - 'package-lock.json'
       - 'package.json'
@@ -16,7 +16,7 @@ on:
     paths:
       - 'ruby-sdk/**'
       - 'eppo_core/**'
-      - 'sdk-test-data/**'
+      - 'sdk-test-data'
       - 'mock-server/**'
       - 'package-lock.json'
       - 'package.json'


### PR DESCRIPTION
Example sdk-test-data update not triggering CI: https://github.com/Eppo-exp/eppo-multiplatform/pull/237

Note that it triggered Dart SDK checks but not other SDKs. This happens because sdk-test-data is a submodule, so it's treated as a file (not directory) during checking for updates.

This PR removes `/**` from all sdk-test-data patterns (same as in dart.yml), so it should trigger the rest of checks.