### PR TITLE
[elixir] add files to package

### DIFF
--- a/.changeset/tidy-trees-rhyme.md
+++ b/.changeset/tidy-trees-rhyme.md
@@ -1,0 +1,5 @@
+---
+"elixir-sdk": patch
+---
+
+Add native/core_sdk to package.files

--- a/elixir-sdk/mix.exs
+++ b/elixir-sdk/mix.exs
@@ -49,7 +49,8 @@ defmodule EppoSdk.MixProject do
         "GitHub" => "https://github.com/Eppo-exp/eppo-multiplatform/tree/main/elixir-sdk",
         "Eppo" => "https://www.geteppo.com",
         "Documentation" => "https://docs.geteppo.com/sdks/server-sdks/"
-      }
+      },
+      files: ~w(lib native/sdk_core mix.exs README.md LICENSE)
     ]
   end
 end


### PR DESCRIPTION
Having trouble compiling the Elixir SDK in an example app. Hopefully this fixes it:

`could not compile dependency :eppo_sdk, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile eppo_sdk --force", update it with "mix deps.update eppo_sdk" or clean it with "mix deps.clean eppo_sdk"`