### PR TITLE
chore(ruby): prebuild for 3.4

### DIFF
--- a/.changeset/neat-ghosts-press.md
+++ b/.changeset/neat-ghosts-press.md
@@ -1,0 +1,5 @@
+---
+"ruby-sdk": patch
+---
+
+Bump rb_sys to support Ruby 3.4. Also adds prebuilt libraries for Ruby 3.4.

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,4 +1,3 @@
----
 name: Ruby SDK
 
 on:
@@ -12,6 +11,7 @@ on:
       - 'mock-server/**'
       - 'package-lock.json'
       - 'package.json'
+      - '.github/workflows/ruby.yml'
   pull_request:
     paths:
       - 'ruby-sdk/**'
@@ -20,6 +20,7 @@ on:
       - 'mock-server/**'
       - 'package-lock.json'
       - 'package.json'
+      - '.github/workflows/ruby.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,7 +33,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby:
+          - "3.0"
+          - "3.1"
+          - "3.2"
+          - "3.3"
+          - "3.4"
 
     steps:
       - uses: actions/checkout@v4

--- a/ruby-sdk/Cargo.lock
+++ b/ruby-sdk/Cargo.lock
@@ -1226,18 +1226,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.103"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91dbe37ab6ac2fba187480fb6544b92445e41e5c6f553bf0c33743f3c450a1df"
+checksum = "becea799ce051c16fb140be80f5e7cf781070f99ca099332383c2b17861249af"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.103"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d56a49dcb646b70b758789c0d16c055a386a4f2a3346333abb69850fa860ce"
+checksum = "64691175abc704862f60a9ca8ef06174080cc50615f2bf1d4759f46db18b4d29"
 dependencies = [
  "bindgen",
  "lazy_static",

--- a/ruby-sdk/ext/eppo_client/Cargo.toml
+++ b/ruby-sdk/ext/eppo_client/Cargo.toml
@@ -17,6 +17,6 @@ log = { version = "0.4.21", features = ["kv_serde"] }
 magnus = { version = "0.7.1" }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_magnus = "0.9.0"
-rb-sys = "0.9.102"
+rb-sys = "0.9.105"
 serde_json = "1.0.128"
 tokio = { version = "1.44.1", default-features = false, features = ["time"] }


### PR DESCRIPTION
[//]: #  (Link to the issue corresponding to this chunk of work)

## Description
[//]: # (Describe your changes in detail)
This bumps rb_sys to support latest Ruby version. Also adds prebuilt binaries for Ruby 3.4.

## How has this been documented?
[//]: # (Please describe how you documented the developer impact of your changes; link to PRs or issues or explain why no documentation changes are required)
Changelog entry

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

Checked the workflow passes in another branch: https://github.com/Eppo-exp/eppo-multiplatform/actions/runs/14595367078/job/40939859313