### PR TITLE
chore: make dependabot update nested lock files as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,14 @@ updates:
       interval: "daily"
 
   - package-ecosystem: cargo
-    directory: "/"
+    directories:
+      - "/eppo_core"
+      - "/rust-sdk"
+      - "/python-sdk"
+      - "/ruby-sdk"
+      - "/elixir-sdk"
     schedule:
       interval: "weekly"
-
 
   - package-ecosystem: pip
     directory: "/python-sdk"


### PR DESCRIPTION
Found that dependabot wasn't bumping Ruby SDK lockfile. Adding ruby-sdk directory explicitly should fix that.

Note that this does remove root directory, so the root lockfile will not get updated. That should be fine as it is unused for releases (and we should probably remove it altogether libraries shouldn't normally have lockfiles committed).

