### PR TITLE
chore(ruby): actually prebuild for ruby-3.4

### DIFF
--- a/.changeset/cool-points-care.md
+++ b/.changeset/cool-points-care.md
@@ -1,0 +1,5 @@
+---
+"ruby-sdk": patch
+---
+
+Add prebuilt libraries for Ruby 3.4.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -181,8 +181,8 @@ jobs:
           echo "Docker Working Directory: $(pwd)"
           set -x
 
-          # We can't actually parallelize the Ruby versions because
-          # they get bundled into the same gem.
+          # We can't parallelize the Ruby versions because they get
+          # bundled into the same gem.
           #
           # However, not parallelizing versions is actually helpful
           # because Cargo is able to reuse most of compile work
@@ -190,7 +190,7 @@ jobs:
           rb-sys-dock \
             --platform ${{ matrix._.platform }} \
             --mount-toolchains \
-            --ruby-versions 3.3,3.2,3.1,3.0 \
+            --ruby-versions 3.4,3.3,3.2,3.1,3.0 \
             --build \
             -- ${{ matrix._.rb-sys-dock-setup }}
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,6 +33,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
+        # NOTE: these versions are only affecting CI check for
+        # PRs. For prebuilt libraries in release, see publish.yml.
         ruby:
           - "3.0"
           - "3.1"

--- a/ruby-sdk/CHANGELOG.md
+++ b/ruby-sdk/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- [#274](https://github.com/Eppo-exp/eppo-multiplatform/pull/274) [`161fb42`](https://github.com/Eppo-exp/eppo-multiplatform/commit/161fb422301bd59c57d4a725a661d3b820c6c5ee) Thanks [@rasendubi](https://github.com/rasendubi)! - Bump rb_sys to support Ruby 3.4. Also adds prebuilt libraries for Ruby 3.4.
+- [#274](https://github.com/Eppo-exp/eppo-multiplatform/pull/274) [`161fb42`](https://github.com/Eppo-exp/eppo-multiplatform/commit/161fb422301bd59c57d4a725a661d3b820c6c5ee) Thanks [@rasendubi](https://github.com/rasendubi)! - Bump rb_sys to support Ruby 3.4.
 
 ## 3.7.0
 


### PR DESCRIPTION
[//]: #  (Link to the issue corresponding to this chunk of work)

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Followup to #274. Found out that I need to update another workflow to actually enable prebuilt libraries for 3.4.

## Description
[//]: # (Describe your changes in detail)

- Actually enable prebuilding binaries for 3.4 on release
- Fix changelog for 3.7.1 as prebuild gem didn't come out
- Add a note in ruby.yml, so it doesn't trip me up again


