### PR TITLE
feat: add more logs when configuration fetch error occurs

### DIFF
--- a/.changeset/smart-melons-march.md
+++ b/.changeset/smart-melons-march.md
@@ -1,0 +1,8 @@
+---
+"eppo_core": patch
+"python-sdk": patch
+"ruby-sdk": patch
+"rust-sdk": patch
+---
+
+Add more logging when configuration fails to fetch.

--- a/eppo_core/src/configuration_poller.rs
+++ b/eppo_core/src/configuration_poller.rs
@@ -148,7 +148,9 @@ async fn configuration_poller(
     };
 
     loop {
-        match fetcher.fetch_configuration().await {
+        match fetcher.fetch_configuration().await.inspect_err(|err| {
+            log::warn!("Failed to fetch configuration: {err:?}");
+        }) {
             Ok(configuration) => {
                 store.set_configuration(Arc::new(configuration));
                 update_status(Ok(()));


### PR DESCRIPTION
Add more logging when configuration fails to fetch. Should help with debugging in the future
